### PR TITLE
Implement _entities field resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,5 +68,5 @@ jobs:
 
       - name: Run dialyzer
         run: |
-          mkdir -p priv/plts
+          mkdir -p priv/plts/{local,core}
           MIX_ENV=test mix dialyzer

--- a/README.md
+++ b/README.md
@@ -26,7 +26,10 @@ Install from github (necesary until package has been published):
 ```elixir
 def deps do
   [
-    {:absinthe_federation, github: "DivvyPayHQ/absinthe_federation", branch: "master"}
+    # Necessary until new version is tagged with this change
+    # https://github.com/absinthe-graphql/absinthe/pull/1069
+    {:absinthe, github: "absinthe-graphql/absinthe", override: true},
+    {:absinthe_federation, github: "DivvyPayHQ/absinthe_federation", branch: "main"}
   ]
 end
 ```

--- a/lib/absinthe/federation/schema/entity_union.ex
+++ b/lib/absinthe/federation/schema/entity_union.ex
@@ -14,8 +14,31 @@ defmodule Absinthe.Federation.Schema.EntityUnion do
       identifier: :_entity,
       module: __MODULE__,
       name: "_Entity",
-      types: types(blueprint)
+      types: types(blueprint),
+      resolve_type: &Absinthe.Federation.Schema.EntityUnion.resolve_type/2
     }
+  end
+
+  # TODO: This is a very naive approach to resolve the union type and should be replaced by something better
+  # Should the library consumer be required to define this union type since they will know how to resolve the types better than we can?
+  def resolve_type(%struct_name{}, _resolution) do
+    struct_name
+    |> Module.split()
+    |> List.last()
+    |> String.downcase()
+    |> String.to_existing_atom()
+  end
+
+  def resolve_type(%{__typename: typename}, _resolution) do
+    typename
+    |> Macro.underscore()
+    |> String.to_existing_atom()
+  end
+
+  def resolve_type(%{"__typename" => typename}, _resolution) do
+    typename
+    |> Macro.underscore()
+    |> String.to_existing_atom()
   end
 
   defp types(node) do

--- a/lib/absinthe/federation/types.ex
+++ b/lib/absinthe/federation/types.ex
@@ -4,7 +4,7 @@ defmodule Absinthe.Federation.Types do
   use Absinthe.Schema.Notation
 
   @desc "The _Any scalar is used to pass representations of entities from external services into the root _entities field for execution."
-  scalar :any, name: "_Any" do
+  scalar :any, name: "_Any", open_ended: true do
     parse fn value -> {:ok, value} end
     serialize fn value -> value end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,11 @@ defmodule Absinthe.Federation.MixProject do
       deps: deps(),
       dialyzer: [
         plt_add_apps: [:mix, :ex_unit],
-        plt_file: {:no_warn, "priv/plts/absinthe_federation.plt"}
+        plt_local_path: "priv/plts/local",
+        plt_core_path:
+          if Mix.env() == :test do
+            "priv/plts/core"
+          end
       ]
     ]
   end
@@ -58,7 +62,7 @@ defmodule Absinthe.Federation.MixProject do
 
   defp deps do
     [
-      {:absinthe, "~> 1.6.4"},
+      {:absinthe, github: "absinthe-graphql/absinthe"},
 
       # Dev
       {:dialyxir, "~> 1.0.0", only: [:dev, :test], runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "absinthe": {:hex, :absinthe, "1.6.4", "d2958908b72ce146698de8ccbc03622630471eb0e354e06823aaef183e5067bd", [:mix], [{:dataloader, "~> 1.0.0", [hex: :dataloader, repo: "hexpm", optional: true]}, {:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}, {:nimble_parsec, "~> 0.5 or ~> 1.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}, {:telemetry, "~> 0.4.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "6e9c1cf36d86c704cb9a9c78db62d1c2676b03e0f61a28a23fc42749e8cd41ae"},
+  "absinthe": {:git, "https://github.com/absinthe-graphql/absinthe.git", "1948513d2103ac68182b64c62c0bf9fc35b96180", []},
   "dialyxir": {:hex, :dialyxir, "1.0.0", "6a1fa629f7881a9f5aaf3a78f094b2a51a0357c843871b8bc98824e7342d00a5", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "aeb06588145fac14ca08d8061a142d52753dbc2cf7f0d00fc1013f53f8654654"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.13", "0c98163e7d04a15feb62000e1a891489feb29f3d10cb57d4f845c405852bbef8", [:mix], [], "hexpm", "d602c26af3a0af43d2f2645613f65841657ad6efc9f0e361c3b6c06b578214ba"},
   "erlex": {:hex, :erlex, "0.2.6", "c7987d15e899c7a2f34f5420d2a2ea0d659682c06ac607572df55a43753aa12e", [:mix], [], "hexpm", "2ed2e25711feb44d52b17d2780eabf998452f6efda104877a3881c2f8c0c0c75"},
@@ -8,5 +8,5 @@
   "makeup_elixir": {:hex, :makeup_elixir, "0.15.1", "b5888c880d17d1cc3e598f05cdb5b5a91b7b17ac4eaf5f297cb697663a1094dd", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.1", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "db68c173234b07ab2a07f645a5acdc117b9f99d69ebf521821d89690ae6c6ec8"},
   "makeup_erlang": {:hex, :makeup_erlang, "0.1.1", "3fcb7f09eb9d98dc4d208f49cc955a34218fc41ff6b84df7c75b3e6e533cc65f", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "174d0809e98a4ef0b3309256cbf97101c6ec01c4ab0b23e926a9e17df2077cbb"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.1.0", "3a6fca1550363552e54c216debb6a9e95bd8d32348938e13de5eda962c0d7f89", [:mix], [], "hexpm", "08eb32d66b706e913ff748f11694b17981c0b04a33ef470e33e11b3d3ac8f54b"},
-  "telemetry": {:hex, :telemetry, "0.4.3", "a06428a514bdbc63293cd9a6263aad00ddeb66f608163bdec7c8995784080818", [:rebar3], [], "hexpm", "eb72b8365ffda5bed68a620d1da88525e326cb82a75ee61354fc24b844768041"},
+  "telemetry": {:hex, :telemetry, "0.4.3", "a06428a514bdbc63293cd9a6263aad00ddeb66f608163bdec7c8995784080818", [:rebar3], [], "hexpm", "eb72b8365ffda5bed68a620d1da88525e326cb82a75ee61354fc24b844768041"}
 }

--- a/test/absinthe/federation/schema/entities_field_test.exs
+++ b/test/absinthe/federation/schema/entities_field_test.exs
@@ -49,10 +49,26 @@ defmodule Absinthe.Federation.Schema.EntitiesFieldTest do
       query do
         field :test, :string
       end
+
+      object :product do
+        field :upc, non_null(:string)
+
+        field :_resolve_reference, :product do
+          resolve(fn _, args, _ -> {:ok, args} end)
+        end
+      end
     end
 
     test "forwards call to correct resolver" do
-      {:ok, %{}} = EntitiesField.resolver(%{}, %{}, %{schema: ResolverSchema})
+      upc = "123"
+      representation = %{"__typename" => "Product", "upc" => upc}
+
+      {:ok, [args]} =
+        EntitiesField.resolver(%{}, %{representations: [representation]}, %{
+          schema: ResolverSchema
+        })
+
+      assert args == %{__typename: "Product", upc: upc}
     end
   end
 


### PR DESCRIPTION
This finishes the implementation for the _entities field resolution by allowing a type to implement the `:_resolve_reference` field.  This is optional and the fallback is to just forward the representation from the gateway as the parent.