### PR TITLE
Fix/duplicate resolvers

### DIFF
--- a/lib/absinthe/federation/schema/entities_field.ex
+++ b/lib/absinthe/federation/schema/entities_field.ex
@@ -97,7 +97,7 @@ defmodule Absinthe.Federation.Schema.EntitiesField do
       end)
       |> Enum.flat_map(fn resolvers ->
         case resolvers do
-          {{:dataloader, _}, v} -> [List.first(v)]
+          {{:dataloader, _}, v} -> Enum.take(v, 1)
           {{:resolver, _}, v} -> v
         end
       end)

--- a/lib/absinthe/federation/schema/entities_field.ex
+++ b/lib/absinthe/federation/schema/entities_field.ex
@@ -84,17 +84,26 @@ defmodule Absinthe.Federation.Schema.EntitiesField do
   def call(%{state: :unresolved} = resolution, _args) do
     resolutions = resolver(resolution.source, resolution.arguments, resolution)
 
-    value =
-      Enum.uniq_by(resolutions, fn %{middleware: [middleware | _remaining_middleware]} = r ->
+    resolvers =
+      Enum.group_by(resolutions, fn %{middleware: [middleware | _remaining_middleware]} = r ->
         case middleware do
           {Absinthe.Middleware.Dataloader, {loader, _fun}} ->
             {source, _} = find_relevant_dataloader(loader)
-            source
+            {:dataloader, source}
 
           _ ->
-            r
+            {:resolver, r}
         end
       end)
+      |> Enum.flat_map(fn resolvers ->
+        case resolvers do
+          {{:dataloader, _}, v} -> [List.first(v)]
+          {{:resolver, _}, v} -> v
+        end
+      end)
+
+    value =
+      resolvers
       |> Enum.map(&reduce_resolution/1)
       |> List.flatten()
 

--- a/test/absinthe/federation/schema/entity_union_test.exs
+++ b/test/absinthe/federation/schema/entity_union_test.exs
@@ -83,7 +83,7 @@ defmodule Absinthe.Federation.Schema.EntityUnionTest do
     test "correct object type returned" do
       query = """
         {
-          _entities(representations: [{__typename: "CreditApplication", id: "123"}, {__typename: "Product", upc: "321"}, {__typename: "SpecItem", item_id: "456"}]) {
+          _entities(representations: [{__typename: "CreditApplication", id: "123"}, {__typename: "Product", upc: "321"}, {__typename: "SpecItem", item_id: "456"}, {__typename: "SpecItem", item_id: "456"}]) {
             ...on CreditApplication {
               id
             }
@@ -97,11 +97,13 @@ defmodule Absinthe.Federation.Schema.EntityUnionTest do
         }
       """
 
-      %{data: %{"_entities" => [credit_app, product, spec_item]}} = Absinthe.run!(query, ResolveTypeSchema)
+      %{data: %{"_entities" => [spec_item, spec_item_two, credit_app, product]}} =
+        Absinthe.run!(query, ResolveTypeSchema)
 
       assert credit_app == %{"id" => "123"}
       assert product == %{"upc" => "321"}
       assert spec_item == %{"itemId" => "456"}
+      assert spec_item_two == %{"itemId" => "456"}
     end
 
     test "error handling" do


### PR DESCRIPTION
Fixes #32. So this fixes the issue where entities wasn't resolved if the same id was passed in several times and the underlying resolver func was a regular resolver.