### PR TITLE
Use snake_cased parent type keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
   > Previously, the entity resolvers had a parent map with atom keys that were
   > camelCased if the field name in the query was camelCased. With this version,
   > the parent type's keys will be converted to internal naming convention of
-  > Absinthe, defaulting to snake_cased key names.
+  > your Absinthe.Adapter, defaulting to snake_cased key names.
   >
   > You may need to update your extended type resolvers to receive parent type
   > maps with snake_cased keys.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.3.0
+
+- **BREAKING**: [Parent type for entities have properly-cased keys](https://github.com/DivvyPayHQ/absinthe_federation/pull/59)
+  > Previously, the entity resolvers had a parent map with atom keys that were
+  > camelCased if the field name in the query was camelCased. With this version,
+  > the parent type's keys will be converted to internal naming convention of
+  > Absinthe, defaulting to snake_cased key names.
+  >
+  > You may need to update your extended type resolvers to receive parent type
+  > maps with snake_cased keys.
+
 ## 0.2.53
 
 - [Update directives to match @apollo/subgraph](https://github.com/DivvyPayHQ/absinthe_federation/pull/58)

--- a/lib/absinthe/federation/schema/entities_field.ex
+++ b/lib/absinthe/federation/schema/entities_field.ex
@@ -160,8 +160,8 @@ defmodule Absinthe.Federation.Schema.EntitiesField do
       {:error,
        "The _entities resolver tried to load an entity for type '#{Map.get(representation, "__typename")}', but no object type of that name was found in the schema"}
 
-  defp resolve_reference(nil, _parent, representation, _resolution) do
-    args = convert_keys_to_atom(representation)
+  defp resolve_reference(nil, _parent, representation, %{context: context} = _resolution) do
+    args = convert_keys_to_atom(representation, context)
 
     fn _, _ -> {:ok, args} end
   end
@@ -170,9 +170,9 @@ defmodule Absinthe.Federation.Schema.EntitiesField do
          %{middleware: middleware},
          parent,
          representation,
-         %{schema: schema} = resolution
+         %{schema: schema, context: context} = resolution
        ) do
-    args = convert_keys_to_atom(representation)
+    args = convert_keys_to_atom(representation, context)
 
     middleware
     |> Absinthe.Middleware.unshim(schema)
@@ -190,18 +190,31 @@ defmodule Absinthe.Federation.Schema.EntitiesField do
     end
   end
 
-  defp convert_keys_to_atom(map) when is_map(map) do
+  defp convert_keys_to_atom(map, context) when is_map(map) do
     map
     |> Enum.reduce(%{}, fn {k, v}, acc ->
-      k = convert_key(k)
-      v = convert_keys_to_atom(v)
+      k = convert_key(k, context)
+      v = convert_keys_to_atom(v, context)
       Map.put(acc, k, v)
     end)
   end
 
-  defp convert_keys_to_atom(v), do: v
+  defp convert_keys_to_atom(v, _context), do: v
 
-  defp convert_key(k), do: k |> LanguageConventions.to_internal_name(:field) |> String.to_atom()
+  defp convert_key(k, context) do
+    adapter = Map.get(context, :adapter, LanguageConventions)
+
+    if adapter_has_to_internal_name_modifier?(adapter) do
+      adapter.to_internal_name(k, :field)
+    else
+      k
+    end
+    |> String.to_atom()
+  end
+
+  defp adapter_has_to_internal_name_modifier?(adapter) do
+    Keyword.get(adapter.__info__(:functions), :to_internal_name) == 2
+  end
 
   defp only_resolver_middleware({{Absinthe.Resolution, :call}, _}), do: true
 

--- a/lib/absinthe/federation/schema/entities_field.ex
+++ b/lib/absinthe/federation/schema/entities_field.ex
@@ -1,6 +1,7 @@
 defmodule Absinthe.Federation.Schema.EntitiesField do
   @moduledoc false
 
+  alias Absinthe.Adapter.LanguageConventions
   alias Absinthe.Blueprint
   alias Absinthe.Blueprint.Schema.FieldDefinition
   alias Absinthe.Blueprint.Schema.InputValueDefinition
@@ -200,7 +201,7 @@ defmodule Absinthe.Federation.Schema.EntitiesField do
 
   defp convert_keys_to_atom(v), do: v
 
-  defp convert_key(k), do: String.to_atom(k)
+  defp convert_key(k), do: k |> LanguageConventions.to_internal_name(:field) |> String.to_atom()
 
   defp only_resolver_middleware({{Absinthe.Resolution, :call}, _}), do: true
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Absinthe.Federation.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/DivvyPayHQ/absinthe_federation"
-  @version "0.2.53"
+  @version "0.3.0"
 
   def project do
     [


### PR DESCRIPTION
  Previously, the entity resolvers had a parent map with atom keys that were camelCased if the field names in the query were camelCased. With this update, the parent type's keys will be converted to internal naming convention of Absinthe, defaulting to snake_cased key names.
  