### PR TITLE
Convert snake_cased field names to camelCased in @key directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,9 @@
   > with `key_fields("some_long_key_name")`, it translated to
   > `@key(fields: "some_long_key_name")` in the schema.
   >
-  > With this version, adding snake_cased keys with this directive will properly
-  > convert them to camelCased versions in the schema, such as
+  > With this version, adding snake_cased keys with this directive will be
+  > converted to the external naming convention of your Absinthe.Adapter,
+  > defaulting to camelCased field, such as
   > `key_fields("some_long_key_name")` resulting in
   > `@key(fields: "someLongKeyName")`.
   >

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 0.3.0
 
-- **BREAKING**: [Parent type for entities have properly-cased keys](https://github.com/DivvyPayHQ/absinthe_federation/pull/59)
+- **BREAKING**: [Parent type for entities to have properly-cased keys](https://github.com/DivvyPayHQ/absinthe_federation/pull/59)
+
   > Previously, the entity resolvers had a parent map with atom keys that were
   > camelCased if the field name in the query was camelCased. With this version,
   > the parent type's keys will be converted to internal naming convention of
@@ -10,6 +11,25 @@
   >
   > You may need to update your extended type resolvers to receive parent type
   > maps with snake_cased keys.
+
+- **BREAKING**: [@key directive to convert snake_cased field names to camelCased](https://github.com/DivvyPayHQ/absinthe_federation/pull/60)
+
+  > Previously, the key_fields directive was used with camelCased field names,
+  > such as `key_fields("someLongKeyName")`. This translated to
+  > `@key(fields: "someLongKeyName")` in the schema. If the directive was added
+  > with `key_fields("some_long_key_name")`, it translated to
+  > `@key(fields: "some_long_key_name")` in the schema.
+  >
+  > With this version, adding snake_cased keys with this directive will properly
+  > convert them to camelCased versions in the schema, such as
+  > `key_fields("some_long_key_name")` resulting in
+  > `@key(fields: "someLongKeyName")`.
+  >
+  > - If you were using the key_fields directive with camelCased field names,
+  >   they may be refactored later since they will not be modified.
+  > - If you were using it with snake_cased field names such as
+  >   `key_fields("some_long_key_name")` you may need to make sure this change
+  >   does not affect your schema.
 
 ## 0.2.53
 

--- a/lib/absinthe/federation/schema/directive.ex
+++ b/lib/absinthe/federation/schema/directive.ex
@@ -1,6 +1,7 @@
 defmodule Absinthe.Federation.Schema.Directive do
   @moduledoc false
 
+  alias Absinthe.Adapter.LanguageConventions
   alias Absinthe.Blueprint
   alias Absinthe.Blueprint.Directive, as: BlueprintDirective
   alias Absinthe.Blueprint.Input.Argument
@@ -28,12 +29,18 @@ defmodule Absinthe.Federation.Schema.Directive do
   def build(name, fields) when is_binary(name) and is_list(fields) do
     %BlueprintDirective{
       __reference__: Notation.build_reference(__ENV__),
-      name: name,
-      arguments: build_arguments(fields)
+      name: to_external_name(name),
+      arguments: build_arguments(name, fields)
     }
   end
 
-  defp build_arguments(fields) when is_list(fields) do
+  defp build_arguments("key", fields) when is_list(fields) do
+    fields
+    |> Enum.map(fn {key, value} -> {key, to_external_name(value)} end)
+    |> Enum.map(&build_argument/1)
+  end
+
+  defp build_arguments(_name, fields) when is_list(fields) do
     Enum.map(fields, &build_argument/1)
   end
 
@@ -47,5 +54,15 @@ defmodule Absinthe.Federation.Schema.Directive do
       },
       source_location: %SourceLocation{line: 0, column: 0}
     }
+  end
+
+  defp to_external_name(key) when is_atom(key) do
+    key
+    |> Atom.to_string()
+    |> to_external_name
+  end
+
+  defp to_external_name(key) when is_binary(key) do
+    LanguageConventions.to_external_name(key, :directive)
   end
 end

--- a/lib/absinthe/federation/schema/phase/add_federated_directives.ex
+++ b/lib/absinthe/federation/schema/phase/add_federated_directives.ex
@@ -10,16 +10,17 @@ defmodule Absinthe.Federation.Schema.Phase.AddFederatedDirectives do
   @dialyzer {:nowarn_function, add_directive: 2}
 
   def run(%Blueprint{} = blueprint, _) do
-    blueprint = Blueprint.postwalk(blueprint, &collect_types/1)
+    adapter = Map.get(blueprint, :adapter, LanguageConventions)
+    blueprint = Blueprint.postwalk(blueprint, &collect_types(&1, adapter))
     {:ok, blueprint}
   end
 
-  defp collect_types(%{__private__: _private} = node) do
-    meta = Type.meta(node)
+  defp collect_types(%{__private__: _private} = node, adapter) do
+    meta = node |> Type.meta() |> Map.put_new(:absinthe_adapter, adapter)
     maybe_add_directives(node, meta)
   end
 
-  defp collect_types(node), do: node
+  defp collect_types(node, _adapter), do: node
 
   @spec maybe_add_directives(term(), any()) :: term()
   defp maybe_add_directives(node, meta) do
@@ -36,78 +37,78 @@ defmodule Absinthe.Federation.Schema.Phase.AddFederatedDirectives do
   end
 
   @spec maybe_add_key_directive(term(), map()) :: term()
-  defp maybe_add_key_directive(node, %{key_fields: fields}) when is_binary(fields) do
-    directive = Directive.build("key", fields: fields)
+  defp maybe_add_key_directive(node, %{key_fields: fields, absinthe_adapter: adapter}) when is_binary(fields) do
+    directive = Directive.build("key", adapter, fields: fields)
 
     add_directive(node, directive)
   end
 
-  defp maybe_add_key_directive(node, %{key_fields: fields}) when is_list(fields) do
+  defp maybe_add_key_directive(node, %{key_fields: fields, absinthe_adapter: adapter}) when is_list(fields) do
     fields
-    |> Enum.map(&Directive.build("key", fields: &1))
+    |> Enum.map(&Directive.build("key", adapter, fields: &1))
     |> Enum.reduce(node, &add_directive(&2, &1))
   end
 
   defp maybe_add_key_directive(node, _meta), do: node
 
-  defp maybe_add_external_directive(node, %{external: true}) do
-    directive = Directive.build("external")
+  defp maybe_add_external_directive(node, %{external: true, absinthe_adapter: adapter}) do
+    directive = Directive.build("external", adapter)
 
     add_directive(node, directive)
   end
 
   defp maybe_add_external_directive(node, _meta), do: node
 
-  defp maybe_add_requires_directive(node, %{requires_fields: fields}) do
-    directive = Directive.build("requires", fields: fields)
+  defp maybe_add_requires_directive(node, %{requires_fields: fields, absinthe_adapter: adapter}) do
+    directive = Directive.build("requires", adapter, fields: fields)
 
     add_directive(node, directive)
   end
 
   defp maybe_add_requires_directive(node, _meta), do: node
 
-  defp maybe_add_provides_directive(node, %{provides_fields: fields}) do
-    directive = Directive.build("provides", fields: fields)
+  defp maybe_add_provides_directive(node, %{provides_fields: fields, absinthe_adapter: adapter}) do
+    directive = Directive.build("provides", adapter, fields: fields)
 
     add_directive(node, directive)
   end
 
   defp maybe_add_provides_directive(node, _meta), do: node
 
-  defp maybe_add_extends_directive(node, %{extends: true}) do
-    directive = Directive.build("extends")
+  defp maybe_add_extends_directive(node, %{extends: true, absinthe_adapter: adapter}) do
+    directive = Directive.build("extends", adapter)
 
     add_directive(node, directive)
   end
 
   defp maybe_add_extends_directive(node, _meta), do: node
 
-  defp maybe_add_shareable_directive(node, %{shareable: true}) do
-    directive = Directive.build("shareable")
+  defp maybe_add_shareable_directive(node, %{shareable: true, absinthe_adapter: adapter}) do
+    directive = Directive.build("shareable", adapter)
 
     add_directive(node, directive)
   end
 
   defp maybe_add_shareable_directive(node, _meta), do: node
 
-  defp maybe_add_override_directive(node, %{override_from: subgraph}) do
-    directive = Directive.build("override", from: subgraph)
+  defp maybe_add_override_directive(node, %{override_from: subgraph, absinthe_adapter: adapter}) do
+    directive = Directive.build("override", adapter, from: subgraph)
 
     add_directive(node, directive)
   end
 
   defp maybe_add_override_directive(node, _meta), do: node
 
-  defp maybe_add_inaccessible_directive(node, %{inaccessible: true}) do
-    directive = Directive.build("inaccessible")
+  defp maybe_add_inaccessible_directive(node, %{inaccessible: true, absinthe_adapter: adapter}) do
+    directive = Directive.build("inaccessible", adapter)
 
     add_directive(node, directive)
   end
 
   defp maybe_add_inaccessible_directive(node, _meta), do: node
 
-  defp maybe_add_tag_directive(node, %{tag: name}) do
-    directive = Directive.build("tag", name: name)
+  defp maybe_add_tag_directive(node, %{tag: name, absinthe_adapter: adapter}) do
+    directive = Directive.build("tag", adapter, name: name)
 
     add_directive(node, directive)
   end

--- a/test/absinthe/federation/schema/directive_test.exs
+++ b/test/absinthe/federation/schema/directive_test.exs
@@ -31,4 +31,56 @@ defmodule Absinthe.Federation.Schema.DirectiveTest do
              }
            } = argument
   end
+
+  test "builds @key directive with properly cased value" do
+    assert %BlueprintDirective{arguments: [argument]} = Directive.build("key", fields: "some_cased_key")
+
+    assert %Argument{
+             name: "fields",
+             input_value: %RawValue{
+               content: %String{
+                 value: "someCasedKey"
+               }
+             }
+           } = argument
+
+    assert %BlueprintDirective{arguments: [argument]} = Directive.build("key", fields: "someCasedKey")
+
+    assert %Argument{
+             name: "fields",
+             input_value: %RawValue{
+               content: %String{
+                 value: "someCasedKey"
+               }
+             }
+           } = argument
+
+    assert %BlueprintDirective{arguments: [argument]} =
+             Directive.build("key", fields: "some_cased_key { another_cased_key }")
+
+    assert %Argument{
+             name: "fields",
+             input_value: %RawValue{
+               content: %String{
+                 value: "someCasedKey { anotherCasedKey }"
+               }
+             }
+           } = argument
+
+    assert %BlueprintDirective{arguments: [argument]} =
+             Directive.build("key", fields: "someCasedKey { anotherCasedKey }")
+
+    assert %Argument{
+             name: "fields",
+             input_value: %RawValue{
+               content: %String{
+                 value: "someCasedKey { anotherCasedKey }"
+               }
+             }
+           } = argument
+  end
+
+  test "builds directive with properly cased name" do
+    assert %BlueprintDirective{name: "composeDirective"} = Directive.build("compose_directive", name: "@myDirective")
+  end
 end

--- a/test/absinthe/federation/schema/directive_test.exs
+++ b/test/absinthe/federation/schema/directive_test.exs
@@ -1,6 +1,7 @@
 defmodule Absinthe.Federation.Schema.DirectiveTest do
   use Absinthe.Federation.Case, async: true
 
+  alias Absinthe.Adapter.{LanguageConventions, Passthrough, Underscore}
   alias Absinthe.Blueprint.Directive, as: BlueprintDirective
   alias Absinthe.Blueprint.Input.Argument
   alias Absinthe.Blueprint.Input.RawValue
@@ -10,17 +11,17 @@ defmodule Absinthe.Federation.Schema.DirectiveTest do
   test "builds directive with name" do
     name = "extends"
 
-    directive = Directive.build(name)
+    directive = Directive.build(name, nil)
     assert %BlueprintDirective{name: ^name} = directive
   end
 
   test "builds directive without args" do
-    %{arguments: arguments} = Directive.build("extends")
+    %{arguments: arguments} = Directive.build("extends", nil)
     assert Enum.empty?(arguments)
   end
 
   test "builds directive with args" do
-    assert %BlueprintDirective{arguments: [argument]} = Directive.build("key", fields: "id")
+    assert %BlueprintDirective{arguments: [argument]} = Directive.build("key", nil, fields: "id")
 
     assert %Argument{
              name: "fields",
@@ -33,7 +34,7 @@ defmodule Absinthe.Federation.Schema.DirectiveTest do
   end
 
   test "builds @key directive with properly cased value" do
-    assert %BlueprintDirective{arguments: [argument]} = Directive.build("key", fields: "some_cased_key")
+    assert %BlueprintDirective{arguments: [argument]} = Directive.build("key", nil, fields: "some_cased_key")
 
     assert %Argument{
              name: "fields",
@@ -44,7 +45,7 @@ defmodule Absinthe.Federation.Schema.DirectiveTest do
              }
            } = argument
 
-    assert %BlueprintDirective{arguments: [argument]} = Directive.build("key", fields: "someCasedKey")
+    assert %BlueprintDirective{arguments: [argument]} = Directive.build("key", nil, fields: "someCasedKey")
 
     assert %Argument{
              name: "fields",
@@ -56,7 +57,7 @@ defmodule Absinthe.Federation.Schema.DirectiveTest do
            } = argument
 
     assert %BlueprintDirective{arguments: [argument]} =
-             Directive.build("key", fields: "some_cased_key { another_cased_key }")
+             Directive.build("key", nil, fields: "some_cased_key { another_cased_key }")
 
     assert %Argument{
              name: "fields",
@@ -68,7 +69,7 @@ defmodule Absinthe.Federation.Schema.DirectiveTest do
            } = argument
 
     assert %BlueprintDirective{arguments: [argument]} =
-             Directive.build("key", fields: "someCasedKey { anotherCasedKey }")
+             Directive.build("key", nil, fields: "someCasedKey { anotherCasedKey }")
 
     assert %Argument{
              name: "fields",
@@ -80,7 +81,19 @@ defmodule Absinthe.Federation.Schema.DirectiveTest do
            } = argument
   end
 
-  test "builds directive with properly cased name" do
-    assert %BlueprintDirective{name: "composeDirective"} = Directive.build("compose_directive", name: "@myDirective")
+  test "builds directive with properly cased name by default" do
+    assert %BlueprintDirective{name: "composeDirective"} =
+             Directive.build("compose_directive", nil, name: "@myDirective")
+  end
+
+  test "builds directive with custom absinthe adapters" do
+    assert %BlueprintDirective{name: "composeDirective"} =
+             Directive.build("compose_directive", LanguageConventions, name: "@myDirective")
+
+    assert %BlueprintDirective{name: "compose_directive"} =
+             Directive.build("compose_directive", Passthrough, name: "@myDirective")
+
+    assert %BlueprintDirective{name: "compose_directive"} =
+             Directive.build("compose_directive", Underscore, name: "@myDirective")
   end
 end

--- a/test/absinthe/federation/schema/service_field_test.exs
+++ b/test/absinthe/federation/schema/service_field_test.exs
@@ -104,7 +104,7 @@ defmodule Absinthe.Federation.Schema.ServiceFieldTest do
       end
 
       object :user do
-        key_fields(["id", "email"])
+        key_fields(["id", "email", "secondary_id"])
         field :id, non_null(:id)
         field :email, non_null(:string)
         field :address, non_null(:address)
@@ -152,6 +152,7 @@ defmodule Absinthe.Federation.Schema.ServiceFieldTest do
       assert sdl =~ "query: RootQueryType"
       assert sdl =~ "@key(fields: \"id\")"
       assert sdl =~ "@key(fields: \"email\")"
+      assert sdl =~ "@key(fields: \"secondaryId\")"
     end
 
     test "returns sdl with types on extended types" do


### PR DESCRIPTION
Previously, the key_fields directive was used with camelCased field names, such as `key_fields("someLongKeyName")`. This translated to `@key(fields: "someLongKeyName")` in the schema. If the directive was added with `key_fields("some_long_key_name")`, it translated to `@key(fields: "some_long_key_name")` in the schema. 

With this update, adding snake_cased keys with this directive will properly convert them to camelCased versions in the schema, such as `key_fields("some_long_key_name")` resulting in `@key(fields: "someLongKeyName")`.
