### PR TITLE
Change in readme to match apollo federation doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ defmodule MyApp.MySchema do
       resolve(&ReviewResolver.get_reviews_for_product/3)
     end
 
-+   field(:_resolve_reference, :product) do
++   field(:__resolve_reference, :product) do
 +     resolve(&ProductResolver.get_product_by_upc/3)
 +   end
   end


### PR DESCRIPTION
According to the doc https://www.apollographql.com/docs/federation/subgraph-spec/#providing-a-mechanism-for-fetching-entities The function should be called `__resolveReference` and not `_resolveReference` hence changing this typo.