### PR TITLE
Fix example of calling `query` macro with args

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,11 +165,11 @@ defmodule MyApp.MySchema do
 +   mutation_type_name: "MyCustomMutationType"
 + )
 
-  query, name: "MyCustomQueryType" do
+  query name: "MyCustomQueryType" do
     ...
   end
 
-  query, name: "MyCustomMutationType" do
+  query name: "MyCustomMutationType" do
     ...
   end
 end


### PR DESCRIPTION
The example has an extra comma between the macro and the first keyword option, which should not be there.