### PR TITLE
Fix BadMapError + other iteration improvements

### DIFF
--- a/test/absinthe/federation/schema/entities_field_test.exs
+++ b/test/absinthe/federation/schema/entities_field_test.exs
@@ -182,6 +182,8 @@ defmodule Absinthe.Federation.Schema.EntitiesFieldTest do
       def context(ctx) do
         loader =
           Dataloader.new(get_policy: :return_nil_on_error)
+          |> Dataloader.add_source(ASourceWithNonmapBatchesKey, struct(ASourceWithNonmapBatchesKey))
+          |> Dataloader.add_source(ASourceWithoutBatchesKey, struct(ASourceWithoutBatchesKey))
           |> Dataloader.add_source(
             SpecItem.Loader,
             SpecItem.Loader.data()
@@ -205,6 +207,8 @@ defmodule Absinthe.Federation.Schema.EntitiesFieldTest do
           resolve(fn _root, %{item_id: id} = args, info ->
             dataloader(SpecItem.Loader).(id, args, info)
           end)
+
+          # resolve dataloader(SpecItem.Loader)
         end
       end
     end

--- a/test/absinthe/federation/schema/entities_field_test.exs
+++ b/test/absinthe/federation/schema/entities_field_test.exs
@@ -207,8 +207,6 @@ defmodule Absinthe.Federation.Schema.EntitiesFieldTest do
           resolve(fn _root, %{item_id: id} = args, info ->
             dataloader(SpecItem.Loader).(id, args, info)
           end)
-
-          # resolve dataloader(SpecItem.Loader)
         end
       end
     end

--- a/test/support/a_source_with_nonmap_batches_key.ex
+++ b/test/support/a_source_with_nonmap_batches_key.ex
@@ -1,0 +1,12 @@
+defmodule ASourceWithNonmapBatchesKey do
+  defstruct batches: []
+
+  defimpl Dataloader.Source do
+    def load(source, _batch_key, _item_key), do: source
+    def run(source), do: source
+    def fetch(_source, _batch_key, _item_key), do: {:ok, nil}
+    def pending_batches?(_source), do: false
+    def put(source, _batch_key, _item_key, _item), do: source
+    def timeout(_source), do: 1000
+  end
+end

--- a/test/support/a_source_without_batches_key.ex
+++ b/test/support/a_source_without_batches_key.ex
@@ -1,0 +1,12 @@
+defmodule ASourceWithoutBatchesKey do
+  defstruct []
+
+  defimpl Dataloader.Source do
+    def load(source, _batch_key, _item_key), do: source
+    def run(source), do: source
+    def fetch(_source, _batch_key, _item_key), do: {:ok, nil}
+    def pending_batches?(_source), do: false
+    def put(source, _batch_key, _item_key, _item), do: source
+    def timeout(_source), do: 1000
+  end
+end


### PR DESCRIPTION
The `find_relevant_dataloader` function was calling `Map.keys` on a term that might not be a map at all (it is an internal field of a Dataloader source).

This change uses the protocol's `pending_batches?` function instead.

Moreover, a number of small iteration improvements are added:

- Use `Map.new` to build maps from existing enumerables
- Use `Enum.find` instead of `Enum.filter` + `List.first`
- Prepend to lists in iteration and reverse at the end instead of concatenating
- pattern match on function head instead of in case form.