### PR TITLE
Fix introspection query failing with "Cannot return null for non-nullable field"

### DIFF
--- a/lib/absinthe/federation/schema.ex
+++ b/lib/absinthe/federation/schema.ex
@@ -28,6 +28,7 @@ defmodule Absinthe.Federation.Schema do
 
       use Absinthe.Federation.Notation
       import_types Absinthe.Federation.Types
+      import_types Absinthe.Federation.Schema.Prototype
     end
   end
 


### PR DESCRIPTION
The introspection query is currently failing due to argument types for the `@link` directive not resolving properly, as they don't seem to get actually imported from `Absinthe.Federation.Schema.Prototype`.

This PR adds a `import_type` statement to fix that.