### PR TITLE
Relax dataloader dependency versions to allow version 2 and above

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -63,7 +63,7 @@ defmodule Absinthe.Federation.MixProject do
   defp deps do
     [
       {:absinthe, "~> 1.6.5 or ~> 1.7.0 or ~> 1.7.1"},
-      {:dataloader, "~> 1.0.9 or ~> 1.0.10"},
+      {:dataloader, "~> 1.0.9 or ~> 1.0.10 or ~> 2.0"},
 
       # Dev
       {:dialyxir, ">= 1.0.0", only: [:dev, :test], runtime: false},


### PR DESCRIPTION
Using [Dataloader](https://hexdocs.pm/dataloader/Dataloader.html) with version >= 2.0 in a project makes it impossible to also use `absinthe_federation`.

As mentioned in the [issue](https://github.com/DivvyPayHQ/absinthe_federation/issues/83) it looks fine to relax the version constraint.