### PR TITLE
Revert "Relax dataloader dependency versions to allow version 2 and above"

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -63,7 +63,7 @@ defmodule Absinthe.Federation.MixProject do
   defp deps do
     [
       {:absinthe, "~> 1.6.5 or ~> 1.7.0 or ~> 1.7.1"},
-      {:dataloader, "~> 1.0.9 or ~> 1.0.10 or ~> 2.0"},
+      {:dataloader, "~> 1.0.9 or ~> 1.0.10"},
 
       # Dev
       {:dialyxir, ">= 1.0.0", only: [:dev, :test], runtime: false},


### PR DESCRIPTION
Reverts DivvyPayHQ/absinthe_federation#84

Dataloader version 2 and above is only supported by absinthe version 1.7.5 and above.
We need to update the absinthe dependency to allow that version as well for this to work.