### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.4.0
+
+- Feature: [Support Absinthe v1.7.2+ and Dataloader v2+](https://github.com/DivvyPayHQ/absinthe_federation/pull/87)
+- **BREAKING**: `link/1` macro removed in favor of
+  ["extend schema" method](README.md#federation-v2) (drop-in replacement).
+- **BREAKING**: Now requires Absinthe v1.7 or above
+- **BREAKING**: Now requires Elixir v1.12 or above
+
 ## 0.3.2
 
 - Bug Fix: [Handle entity type names with multiple words](https://github.com/DivvyPayHQ/absinthe_federation/pull/68)

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -2,7 +2,7 @@
 
 MIT License
 
-Copyright (c) 2021 DivvyPay, LLC
+Copyright (c) 2024 BILL Operations, LLC.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ end
 ## Usage
 
 ### Macro based schemas (recommended)
-> Note: Implementing the reference resolver with function capture does not work at the moment. Hence, the below example uses an anonymous function. 
+
+> Note: Implementing the reference resolver with function capture does not work at the moment. Hence, the below example uses an anonymous function.
 
 ```elixir
 defmodule MyApp.MySchema do
@@ -75,7 +76,7 @@ defmodule MyApp.MySchema do
     end
 
 +   field(:_resolve_reference, :product) do
-+     resolve(fn parent, args, context -> 
++     resolve(fn parent, args, context ->
         ProductResolver.get_product_by_upc(parent, args, context)
       end)
 +   end
@@ -134,7 +135,7 @@ defmodule MyApp.MySchema do
   use Absinthe.Federation.Schema
 
 + extend schema do
-+   directive(:link,
++   directive :link,
 +     url: "https://specs.apollo.dev/federation/v2.0",
 +     import: [
 +       "@key",
@@ -146,7 +147,6 @@ defmodule MyApp.MySchema do
 +       "@override",
 +       "@inaccessible"
 +     ]
-+   )
 + end
 
   query do
@@ -165,11 +165,10 @@ defmodule MyApp.MySchema do
   use Absinthe.Federation.Schema
 
 + extend schema do
-+   directive(:link,
-+     url: "https://specs.apollo.dev/federation/v2.0", 
++   directive :link,
++     url: "https://specs.apollo.dev/federation/v2.0",
 +     import: [%{"name" => "@key", "as" => "@primaryKey"}], # directive renaming
 +     as: "federation" # namespacing
-+   )
 + end
 
   query do

--- a/federation_compatibility/lib/products_web/schema.ex
+++ b/federation_compatibility/lib/products_web/schema.ex
@@ -27,7 +27,7 @@ defmodule ProductsWeb.Schema do
   end
 
   extend schema do
-    directive(:link,
+    directive :link,
       url: "https://specs.apollo.dev/federation/v2.0",
       import: [
         "@extends",
@@ -40,7 +40,6 @@ defmodule ProductsWeb.Schema do
         "@shareable",
         "@tag"
       ]
-    )
   end
 
   @desc """

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Absinthe.Federation.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/DivvyPayHQ/absinthe_federation"
-  @version "0.3.2"
+  @version "0.4.0"
 
   def project do
     [
@@ -35,7 +35,7 @@ defmodule Absinthe.Federation.MixProject do
         "*.exs",
         "*.md"
       ],
-      maintainers: ["Kaden Wilkinson"],
+      maintainers: ["Doruk Gurleyen", "Eric Wolf"],
       licenses: ["MIT"],
       links: %{github: @source_url}
     ]

--- a/test/absinthe/federation/notation_test.exs
+++ b/test/absinthe/federation/notation_test.exs
@@ -10,10 +10,9 @@ defmodule Absinthe.Federation.NotationTest do
       use Absinthe.Federation.Schema
 
       extend schema do
-        directive(:link,
+        directive :link,
           url: "https://specs.apollo.dev/federation/v2.0",
           import: ["@key", "@tag"]
-        )
       end
 
       import_sdl("scalar RandomNumber")
@@ -57,11 +56,10 @@ defmodule Absinthe.Federation.NotationTest do
         use Absinthe.Federation.Schema
 
         extend schema do
-          directive(:link,
+          directive :link,
             url: "https://specs.apollo.dev/federation/v2.0",
             import: ["@key", "@tag"],
             as: "federation"
-          )
         end
 
         query do
@@ -81,11 +79,10 @@ defmodule Absinthe.Federation.NotationTest do
         use Absinthe.Federation.Schema
 
         extend schema do
-          directive(:link,
+          directive :link,
             url: "https://specs.apollo.dev/federation/v2.0",
             import: ["@key", "@tag", %{"name" => "@override", "as" => "@replace"}],
             as: "federation"
-          )
         end
 
         query do


### PR DESCRIPTION
- Feature: [Support Absinthe v1.7.2+ and Dataloader v2+](https://github.com/DivvyPayHQ/absinthe_federation/pull/87)
- **BREAKING**: `link/1` macro removed in favor of ["extend schema" method](README.md#federation-v2) (drop-in replacement).
- **BREAKING**: Now requires Absinthe v1.7 or above
- **BREAKING**: Now requires Elixir v1.12 or above