### PR TITLE
Add `composeDirective` directive, fixes #72

### DIFF
--- a/lib/absinthe/federation/schema/prototype/federated_directives.ex
+++ b/lib/absinthe/federation/schema/prototype/federated_directives.ex
@@ -141,6 +141,19 @@ defmodule Absinthe.Federation.Schema.Prototype.FederatedDirectives do
           :input_field_definition
         ]
       end
+
+      @desc """
+      Indicates to composition that all uses of a particular custom type system directive in the subgraph schema should
+      be preserved in the supergraph schema.
+
+      See [Apollo Federation docs](https://www.apollographql.com/docs/federation/federated-types/federated-directives/#managing-custom-directives)
+      for details.
+      """
+      directive :compose_directive do
+        arg :name, non_null(:string)
+        repeatable true
+        on [:schema]
+      end
     end
   end
 end

--- a/test/absinthe/federation/notation_test.exs
+++ b/test/absinthe/federation/notation_test.exs
@@ -122,7 +122,7 @@ defmodule Absinthe.Federation.NotationTest do
                ~s(schema @link(url: "https:\\/\\/myspecs.example.org\\/myDirective\\/v1.0", import: ["@myDirective"]\) @link(url: "https:\\/\\/specs.apollo.dev\\/federation\\/v2.0", import: ["@key", "@tag"]\))
     end
 
-    test "schema with multiple composeDirectives is valiad" do
+    test "schema with multiple composeDirectives is valid" do
       defmodule ComposePrototype do
         use Absinthe.Schema.Prototype
         use Absinthe.Federation.Schema.Prototype.FederatedDirectives

--- a/test/absinthe/federation/notation_test.exs
+++ b/test/absinthe/federation/notation_test.exs
@@ -121,5 +121,37 @@ defmodule Absinthe.Federation.NotationTest do
       assert sdl =~
                ~s(schema @link(url: "https:\\/\\/myspecs.example.org\\/myDirective\\/v1.0", import: ["@myDirective"]\) @link(url: "https:\\/\\/specs.apollo.dev\\/federation\\/v2.0", import: ["@key", "@tag"]\))
     end
+
+    test "schema with multiple composeDirectives is valiad" do
+      defmodule ComposePrototype do
+        use Absinthe.Schema.Prototype
+        use Absinthe.Federation.Schema.Prototype.FederatedDirectives
+
+        directive :custom do
+          on :schema
+        end
+      end
+
+      defmodule MultipleComposeDirectivesSchema do
+        use Absinthe.Schema
+        use Absinthe.Federation.Schema, skip_prototype: true
+
+        @prototype_schema ComposePrototype
+
+        extend schema do
+          directive :link, url: "https://specs.apollo.dev/federation/v2.1", import: ["@composeDirective"]
+          directive :composeDirective, name: "@custom"
+          directive :composeDirective, name: "@other"
+        end
+
+        query do
+          field :hello, :string
+        end
+      end
+
+      sdl = Absinthe.Schema.to_sdl(MultipleComposeDirectivesSchema)
+
+      assert sdl =~ ~s{schema @composeDirective(name: "@other") @composeDirective(name: "@custom")}
+    end
   end
 end

--- a/test/absinthe/federation/notation_test.exs
+++ b/test/absinthe/federation/notation_test.exs
@@ -130,6 +130,10 @@ defmodule Absinthe.Federation.NotationTest do
         directive :custom do
           on :schema
         end
+
+        directive :other do
+          on :schema
+        end
       end
 
       defmodule MultipleComposeDirectivesSchema do


### PR DESCRIPTION
Pretty straight forward addition of the `composeDirective` directive.

I also considered adding a `compose` macro to notation to facilitate expansion, so that the `link` and `composeDirective` would be automatically added to the schema without having to add them to the `extend schema` block:

```
directive :custom do
  compose "https://spec.example.org/custom/v1.0"
  on [:schema]
end
```

I decided against it for this PR, but if that is something y'all think is worth the effort, let me know and I'll create an issue and do it at some point.

Cheers!