### PR TITLE
Import directive definitions from custom prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,7 @@ If you are already using a schema prototype
 ```elixir
 defmodule MyApp.MySchema do
   use Absinthe.Schema
-+ use Absinthe.Federation.Schema, skip_prototype: true
-
-  @prototype_schema MyApp.MySchemaPrototype
++ use Absinthe.Federation.Schema, prototype_schema: MyApp.MySchemaPrototype
 
   query do
     ...

--- a/federation_compatibility/lib/products_web/schema.ex
+++ b/federation_compatibility/lib/products_web/schema.ex
@@ -1,7 +1,4 @@
 defmodule ProductsWeb.Schema do
-  use Absinthe.Schema
-  use Absinthe.Federation.Schema
-
   defmodule Product do
     defstruct [:id, :sku, :package, :variation]
   end
@@ -26,9 +23,24 @@ defmodule ProductsWeb.Schema do
     defstruct [:email, :name, :total_products_created, :years_of_employment]
   end
 
+  defmodule Prototype do
+    use Absinthe.Schema.Prototype
+    use Absinthe.Federation.Schema.Prototype.FederatedDirectives
+
+    directive :custom do
+      on :object
+    end
+  end
+
+  use Absinthe.Schema
+  use Absinthe.Federation.Schema, prototype_schema: Prototype
+
   extend schema do
+    directive :composeDirective, name: "@custom"
+    directive :link, url: "https://divvypay.com/test/v2.4", import: ["@custom"]
+
     directive :link,
-      url: "https://specs.apollo.dev/federation/v2.0",
+      url: "https://specs.apollo.dev/federation/v2.1",
       import: [
         "@extends",
         "@external",
@@ -38,7 +50,8 @@ defmodule ProductsWeb.Schema do
         "@provides",
         "@requires",
         "@shareable",
-        "@tag"
+        "@tag",
+        "@composeDirective"
       ]
   end
 
@@ -56,6 +69,8 @@ defmodule ProductsWeb.Schema do
   """
   object :product do
     key_fields(["id", "sku package", "sku variation { id }"])
+    directive :custom
+
     field :id, non_null(:id)
     field :sku, :string
     field :package, :string

--- a/lib/absinthe/federation/schema/prototype/federated_directives.ex
+++ b/lib/absinthe/federation/schema/prototype/federated_directives.ex
@@ -1,8 +1,6 @@
 defmodule Absinthe.Federation.Schema.Prototype.FederatedDirectives do
   @moduledoc false
 
-  use Absinthe.Schema.Notation
-
   defmacro __using__(_) do
     quote do
       @desc """

--- a/test/absinthe/federation/notation_test.exs
+++ b/test/absinthe/federation/notation_test.exs
@@ -132,15 +132,13 @@ defmodule Absinthe.Federation.NotationTest do
         end
 
         directive :other do
-          on :schema
+          on :object
         end
       end
 
       defmodule MultipleComposeDirectivesSchema do
         use Absinthe.Schema
-        use Absinthe.Federation.Schema, skip_prototype: true
-
-        @prototype_schema ComposePrototype
+        use Absinthe.Federation.Schema, prototype_schema: ComposePrototype
 
         extend schema do
           directive :link, url: "https://specs.apollo.dev/federation/v2.1", import: ["@composeDirective"]
@@ -149,13 +147,20 @@ defmodule Absinthe.Federation.NotationTest do
         end
 
         query do
-          field :hello, :string
+          field :hello, :user
+        end
+
+        object :user do
+          directive :other
+          field :name, :string
         end
       end
 
       sdl = Absinthe.Schema.to_sdl(MultipleComposeDirectivesSchema)
 
       assert sdl =~ ~s{schema @composeDirective(name: "@other") @composeDirective(name: "@custom")}
+      assert sdl =~ ~s{directive @custom on SCHEMA}
+      assert sdl =~ ~s{directive @other on OBJECT}
     end
   end
 end

--- a/test/absinthe/federation/schema_test.exs
+++ b/test/absinthe/federation/schema_test.exs
@@ -67,20 +67,18 @@ defmodule Absinthe.Federation.SchemaTest do
       use Absinthe.Schema.Prototype
       use Absinthe.Federation.Schema.Prototype.FederatedDirectives
 
-      directive :my_directive do
+      directive :custom do
         on [:schema]
       end
     end
 
     defmodule CustomPrototypeSchema do
       use Absinthe.Schema
-      use Absinthe.Federation.Schema, skip_prototype: true
-
-      @prototype_schema CustomPrototype
+      use Absinthe.Federation.Schema, prototype_schema: CustomPrototype
 
       extend schema do
         directive :link, url: "https://specs.apollo.dev/federation/v2.0", import: ["@tag"]
-        directive :myDirective
+        directive :custom
       end
 
       query do
@@ -91,7 +89,8 @@ defmodule Absinthe.Federation.SchemaTest do
     test "it includes federation and custom directions" do
       sdl = Absinthe.Federation.to_federated_sdl(CustomPrototypeSchema)
 
-      assert sdl =~ "schema @myDirective @link"
+      assert sdl =~ "schema @custom @link"
+      assert sdl =~ "directive @custom on SCHEMA"
     end
   end
 end


### PR DESCRIPTION
Using a custom prototype with the skip_prototype option would fail the federated schema composition because absinthe will not add required directive and type definitions from the prototype. This changes the way we use a custom prototype; instead of providing a skip_prototype boolean and a module attribute for the prototype, we provide the prototype_schema option when we `use Absinthe.Federation.Schema`. This way, the definitions are imported as necessary.

This change also unlocks the @composeDirective support in the federation_compatibility checks. It will finally close #72.