### PR TITLE
Return :ok from mix task

### DIFF
--- a/lib/absinthe/mix/tasks/absinthe.federation.schema.sdl.ex
+++ b/lib/absinthe/mix/tasks/absinthe.federation.schema.sdl.ex
@@ -62,6 +62,7 @@ defmodule Mix.Tasks.Absinthe.Federation.Schema.Sdl do
   defp write_schema(content, filename) do
     create_directory(Path.dirname(filename))
     create_file(filename, content, force: true)
+    :ok
   end
 
   def parse_options(argv) do


### PR DESCRIPTION
It's helpful to be able to generate the schema SDL as a mix compiler, but becase the success path returns `true`, rather then `:ok`, mix returns a warning:

```shell
* creating .
* creating schema.graphql
==>
warning: Mix compiler :graphql_schema_sdl was supposed to return {:ok | :noop | :error, [diagnostic]} but it returned true
```

This PR addresses that warning by updating `write_schema/2` to return :ok.

For those curious, you can set it as a compiler by updating the `alias`, and `compilers` keys the `project` function in your mix.exs.

```elixir
def project do
  [
    aliases: ["compile.graphql_schema_sdl": "absinthe.federation.schema.sdl --schema Schema"],
    compilers:  Mix.compilers() ++ [:graphql_schema_sdl]
  ]
end
```