### PR TITLE
Don't unshim middleware if they aren't shimmed to begin with

### DIFF
--- a/lib/absinthe/federation/schema/entities_field.ex
+++ b/lib/absinthe/federation/schema/entities_field.ex
@@ -173,7 +173,7 @@ defmodule Absinthe.Federation.Schema.EntitiesField do
     args = convert_keys_to_atom(representation, context)
 
     middleware
-    |> Absinthe.Middleware.unshim(schema)
+    |> maybe_unshim(schema)
     |> Enum.find(nil, &only_resolver_middleware/1)
     |> case do
       {_, resolve_ref_func} when is_function(resolve_ref_func, 2) ->
@@ -186,6 +186,11 @@ defmodule Absinthe.Federation.Schema.EntitiesField do
         fn _, _ -> {:ok, args} end
     end
   end
+
+  defp maybe_unshim([{{Absinthe.Middleware, :shim}, {_, _, _}}] = middleware, schema),
+    do: Absinthe.Middleware.unshim(middleware, schema)
+
+  defp maybe_unshim(middleware, _schema), do: middleware
 
   defp convert_keys_to_atom(map, context) when is_map(map) do
     Map.new(map, fn {k, v} ->

--- a/test/absinthe/federation/schema/persistent_term_schema_entity_field_test.exs
+++ b/test/absinthe/federation/schema/persistent_term_schema_entity_field_test.exs
@@ -1,0 +1,86 @@
+defmodule Absinthe.Federation.Schema.PersistentTermSchemaEntityFieldTest do
+  use Absinthe.Federation.Case, async: true
+
+  defmodule EntitySchemaWithPersistentTermProvider do
+    use Absinthe.Schema
+    use Absinthe.Federation.Schema
+
+    @schema_provider Absinthe.Schema.PersistentTerm
+
+    query do
+      field :named_entity, :named_entity
+    end
+
+    interface :named_entity do
+      key_fields("name")
+
+      field :name, :string do
+        resolve(fn %{name: name}, _, _ ->
+          {:ok, name}
+        end)
+      end
+
+      resolve_type(&resolve_type/2)
+
+      field :_resolve_reference, :named_entity do
+        resolve(fn
+          _, %{name: "John"}, _ -> {:ok, %{__typename: "Person", name: "John", age: 20}}
+          _, %{name: "Acme"}, _ -> {:ok, %{__typename: "Business", name: "Acme", employee_count: 10}}
+        end)
+      end
+
+      defp resolve_type(%{age: _}, _), do: :person
+      defp resolve_type(%{empolyee_count: _}, _), do: :business
+      defp resolve_type(_, _), do: nil
+    end
+
+    object :person do
+      key_fields("name")
+
+      interface :named_entity
+      import_fields(:named_entity, [:name, :_resolve_reference])
+      field :age, :integer
+    end
+
+    object :business do
+      key_fields("name")
+
+      interface :named_entity
+      import_fields(:named_entity, [:name, :_resolve_reference])
+      field :employee_count, :integer
+    end
+  end
+
+  test "Resolves entity interfaces with PersistentTerm schema provider" do
+    query = """
+      query {
+        _entities(representations: [
+          { __typename: "NamedEntity", name: "John" },
+          { __typename: "NamedEntity", name: "Acme" }
+        ]) {
+          ...on NamedEntity {
+            __typename
+            name
+            ... on Person {
+              age
+            }
+            ... on Business {
+              employeeCount
+            }
+          }
+        }
+      }
+    """
+
+    {:ok, resp} = Absinthe.run(query, EntitySchemaWithPersistentTermProvider, variables: %{})
+
+    assert %{
+             data: %{
+               "_entities" => [
+                 %{"__typename" => "Person", "name" => "John", "age" => 20},
+                 %{"__typename" => "Business", "name" => "Acme", "employeeCount" => 10}
+               ]
+             }
+           } = resp
+  end
+end


### PR DESCRIPTION
Hi there, this PR fixes an issue we were seeing when deployed in an application. I apologize for the lack of tests, but I'm not entirely sure why this error is happening or how to trigger it in tests. I wrote a few tests but they all pass regardless of the change.

## Error

We're trying to support "Entity Queries" on an Interface, this is the "receiving end" of the `@interfaceObject` directive.

Our schema looks roughly like this:

```elixir
defmodule SchemaWithEntityInterface do
  use Absinthe.Schema
  use Absinthe.Federation.Schema

  query do
    field :named_entity, :named_entity
  end

  interface :named_entity do
    key_fields("name")

    field :name, :string

    resolve_type fn
      %{age: _}, _ -> :person
      %{employee_count: _}, _ -> :business
      _, _ -> nil
    end

    field :_resolve_reference, :named_entity do
      resolve(fn
        _, %{name: "John"}, _ ->
          {:ok, %{__typename: "Person", name: "John", age: 20}}

        _, %{name: "Acme"}, _ ->
          {:ok, %{__typename: "Business", name: "Acme", employee_count: 10}}
      end)
    end
  end

  object :person do
    key_fields("name")

    import_fields(:named_entity, [:name, :_resolve_reference])
    field :age, :integer

    interface :named_entity
  end

  object :business do
    key_fields("name")

    import_fields(:named_entity, [:name, :_resolve_reference])
    field :employee_count, :integer

    interface :named_entity
  end
end
```

When writing unit tests setup like this in `absinthe_federation` it works fine. In our application either in tests or deployed I get the following error. I haven't been able to simplify it enough to figure out the difference between running in my application vs. in `absinthe_federation` unit tests.

```
#PID<0.78989.0> running MyAppWeb.Endpoint (connection #PID<0.78988.0>, stream id 1) terminated
Server: myapp.com:80 (http)
Request: POST /graphql
** (exit) an exception was raised:
    ** (FunctionClauseError) no function clause matching in Absinthe.Middleware.unshim/2
        (absinthe 1.7.6) lib/absinthe/middleware.ex:279: Absinthe.Middleware.unshim([{Absinthe.Middleware.Telemetry, []}, {{Absinthe.Resolution, :call}, #Function<1.131082921/3 in MyAppWeb.Schema.Types.InterfaceEntity.__absinthe_function__/2>}], LiveWeb.Schema)
        (absinthe_federation 0.5.0) lib/absinthe/federation/schema/entities_field.ex:176: Absinthe.Federation.Schema.EntitiesField.resolve_reference/4
        (absinthe_federation 0.5.0) lib/absinthe/federation/schema/entities_field.ex:140: Absinthe.Federation.Schema.EntitiesField.entity_accumulator/3
        (elixir 1.16.0) lib/enum.ex:1700: Enum."-map/2-lists^map/1-1-"/2
        (absinthe_federation 0.5.0) lib/absinthe/federation/schema/entities_field.ex:86: Absinthe.Federation.Schema.EntitiesField.call/2
        (absinthe 1.7.6) lib/absinthe/phase/document/execution/resolution.ex:234: Absinthe.Phase.Document.Execution.Resolution.reduce_resolution/1
        (absinthe 1.7.6) lib/absinthe/phase/document/execution/resolution.ex:189: Absinthe.Phase.Document.Execution.Resolution.do_resolve_field/3
        (absinthe 1.7.6) lib/absinthe/phase/document/execution/resolution.ex:174: Absinthe.Phase.Document.Execution.Resolution.do_resolve_fields/6
```

## PR

Hopefully, this PR makes sense as-is and is useful. If someone can help me better understand how a middleware gets shimmed and why `absinthe_federation` has to call the (seemingly private) `unshim` function. I'd be glad to contribute a more thorough solution with tests.