### PR TITLE
Handle nil results for entity queries

### DIFF
--- a/test/absinthe/federation/schema/entities_field_test.exs
+++ b/test/absinthe/federation/schema/entities_field_test.exs
@@ -63,6 +63,7 @@ defmodule Absinthe.Federation.Schema.EntitiesFieldTest do
               case upc do
                 "123" -> {:ok, args}
                 "456" -> {:ok, args}
+                "nil" <> _ -> {:ok, nil}
                 _ -> {:error, "Couldn't find product with upc #{upc}"}
               end
             end)
@@ -142,6 +143,35 @@ defmodule Absinthe.Federation.Schema.EntitiesFieldTest do
                    path: ["_entities"]
                  }
                ]
+             } = resp
+    end
+
+    test "Handles missing data" do
+      query = """
+        query {
+          _entities(representations: [
+            {
+              __typename: "Product",
+              upc: "nil1"
+            },
+            {
+              __typename: "Product",
+              upc: "nil22"
+            }
+          ]) {
+            __typename
+            ...on Product {
+              upc
+              foo
+            }
+          }
+        }
+      """
+
+      {:ok, resp} = Absinthe.run(query, ResolverSchema, variables: %{})
+
+      assert %{
+               data: %{"_entities" => [nil, nil]}
              } = resp
     end
 


### PR DESCRIPTION
There seems to be a bug wheren if I return `{:ok, nil}` from `_resolve_reference` in an Entity query, I get a strange error like this:

```json
{"data":null,"errors":[{"message":"","path":["_entities"],"locations":[{"line":1,"column":35}]}]}
```

I believe I tracked this down to the code modified in the PR.

I added tests for returning `nil` from `_resolve_references` in both entity and non-entity queries.