### PR TITLE
Fix link directive args

### DIFF
--- a/lib/absinthe/federation/schema/prototype/federated_directives.ex
+++ b/lib/absinthe/federation/schema/prototype/federated_directives.ex
@@ -73,7 +73,7 @@ defmodule Absinthe.Federation.Schema.Prototype.FederatedDirectives do
         arg :url, :string
         arg :as, :string
         arg :for, :link_purpose
-        arg :import, :link_import
+        arg :import, list_of(:link_import)
         repeatable true
         on [:schema]
       end


### PR DESCRIPTION
The `@link` directive's import arg is typed incorrectly according to the federation spec. This commit fixes it.