### PR TITLE
Resolve Entity Interface types

### DIFF
--- a/lib/absinthe/federation/schema/entity_union.ex
+++ b/lib/absinthe/federation/schema/entity_union.ex
@@ -35,7 +35,7 @@ defmodule Absinthe.Federation.Schema.EntityUnion do
          %{name: name, __private__: _private} = node,
          types
        ) do
-    if has_key_directive?(node) do
+    if is_object_type?(node) and has_key_directive?(node) do
       {node, [%Name{name: name} | types]}
     else
       {node, types}
@@ -54,6 +54,9 @@ defmodule Absinthe.Federation.Schema.EntityUnion do
 
   defp is_key_directive?(%{name: "key"} = _directive), do: true
   defp is_key_directive?(_directive), do: false
+
+  defp is_object_type?(%Absinthe.Blueprint.Schema.ObjectTypeDefinition{}), do: true
+  defp is_object_type?(_), do: false
 end
 
 defprotocol Absinthe.Federation.Schema.EntityUnion.Resolver do

--- a/lib/absinthe/federation/schema/entity_union.ex
+++ b/lib/absinthe/federation/schema/entity_union.ex
@@ -87,21 +87,15 @@ defimpl Absinthe.Federation.Schema.EntityUnion.Resolver, for: Any do
   defp inner_resolve_type(data, typename, resolution) do
     type = Absinthe.Schema.lookup_type(resolution.schema, typename)
 
-    if is_nil(type) do
-      to_internal_name(typename, resolution.adapter)
-    else
-      if(Map.has_key?(type, :resolve_type)) do
+    case type do
+      %{resolve_type: resolve_type} when not is_nil(resolve_type) ->
         resolver = Absinthe.Type.function(type, :resolve_type)
+        resolver.(data, resolution)
 
-        if is_nil(resolver) do
-          to_internal_name(typename, resolution.adapter)
-        else
-          resolver.(data, resolution)
-        end
-      else
+      _type ->
         to_internal_name(typename, resolution.adapter)
-      end
     end
+  end
   end
 
   defp to_internal_name(name, adapter) when is_nil(adapter) do

--- a/lib/absinthe/federation/schema/entity_union.ex
+++ b/lib/absinthe/federation/schema/entity_union.ex
@@ -96,7 +96,6 @@ defimpl Absinthe.Federation.Schema.EntityUnion.Resolver, for: Any do
         to_internal_name(typename, resolution.adapter)
     end
   end
-  end
 
   defp to_internal_name(name, adapter) when is_nil(adapter) do
     name

--- a/test/absinthe/federation/schema/entity_union_test.exs
+++ b/test/absinthe/federation/schema/entity_union_test.exs
@@ -218,6 +218,16 @@ defmodule Absinthe.Federation.Schema.EntityUnionTest do
         key_fields("id")
         field :id, non_null(:id)
 
+        field :_resolve_reference, :shape do
+          resolve(fn _, %{id: id} = args, _ ->
+            case id do
+              "123" -> {:ok, args}
+              "321" -> {:ok, args}
+              _ -> {:error, "ID doesn't exist #{id}"}
+            end
+          end)
+        end
+
         resolve_type fn
           data, _ ->
             case data do
@@ -235,6 +245,15 @@ defmodule Absinthe.Federation.Schema.EntityUnionTest do
         field :id, non_null(:id)
 
         interface :shape
+
+        field :_resolve_reference, :circle do
+          resolve(fn _, %{id: id} = args, _ ->
+            case id do
+              "123" -> {:ok, args}
+              _ -> {:error, "ID doesn't exist #{id}"}
+            end
+          end)
+        end
       end
 
       object :rectangle do
@@ -242,6 +261,15 @@ defmodule Absinthe.Federation.Schema.EntityUnionTest do
         field :id, non_null(:id)
 
         interface :shape
+
+        field :_resolve_reference, :rectangle do
+          resolve(fn _, %{id: id} = args, _ ->
+            case id do
+              "321" -> {:ok, args}
+              _ -> {:error, "ID doesn't exist #{id}"}
+            end
+          end)
+        end
       end
     end
 

--- a/test/absinthe/federation/schema/entity_union_test.exs
+++ b/test/absinthe/federation/schema/entity_union_test.exs
@@ -293,8 +293,7 @@ defmodule Absinthe.Federation.Schema.EntityUnionTest do
         }
       """
 
-      %{data: %{"_entities" => [circle, rectangle]}} =
-        Absinthe.run!(query, MacroSchemaWithInterface)
+      %{data: %{"_entities" => [circle, rectangle]}} = Absinthe.run!(query, MacroSchemaWithInterface)
 
       assert circle == %{"id" => "123", "__typename" => "Circle"}
       assert rectangle == %{"id" => "321", "__typename" => "Rectangle"}
@@ -309,8 +308,7 @@ defmodule Absinthe.Federation.Schema.EntityUnionTest do
         }
       """
 
-      %{data: %{"shapes" => [circle, rectangle]}} =
-        Absinthe.run!(query, MacroSchemaWithInterface)
+      %{data: %{"shapes" => [circle, rectangle]}} = Absinthe.run!(query, MacroSchemaWithInterface)
 
       assert circle == %{"id" => "1"}
       assert rectangle == %{"id" => "2"}

--- a/test/absinthe/federation/schema/entity_union_test.exs
+++ b/test/absinthe/federation/schema/entity_union_test.exs
@@ -194,5 +194,34 @@ defmodule Absinthe.Federation.Schema.EntityUnionTest do
       sdl = Absinthe.Schema.to_sdl(SDLSchemaNoTypesForUnionEntity)
       refute sdl =~ "union _Entity"
     end
+
+    defmodule MacroSchemaWithInterface do
+      use Absinthe.Schema
+      use Absinthe.Federation.Schema
+
+      query do
+        field :shapes, list_of(:shape)
+      end
+
+      interface :shape do
+        key_fields("id")
+        field :id, non_null(:id)
+      end
+
+      object :circle do
+        key_fields("id")
+        field :id, non_null(:id)
+      end
+
+      object :rectangle do
+        key_fields("id")
+        field :id, non_null(:id)
+      end
+    end
+
+    test "omits interfaces with keys from the entities union" do
+      sdl = Absinthe.Schema.to_sdl(MacroSchemaWithInterface)
+      assert sdl =~ "union _Entity = Circle | Rectangle"
+    end
   end
 end

--- a/test/support/entity_interface/circle.ex
+++ b/test/support/entity_interface/circle.ex
@@ -4,8 +4,4 @@ defmodule Example.EntityInterface.Circle do
         }
 
   defstruct id: ""
-
-  defimpl Absinthe.Federation.Schema.EntityUnion.Resolver do
-    def resolve_type(_, _), do: :circle
-  end
 end

--- a/test/support/entity_interface/circle.ex
+++ b/test/support/entity_interface/circle.ex
@@ -1,0 +1,11 @@
+defmodule Example.EntityInterface.Circle do
+  @type t :: %__MODULE__{
+          id: String.t()
+        }
+
+  defstruct id: ""
+
+  defimpl Absinthe.Federation.Schema.EntityUnion.Resolver do
+    def resolve_type(_, _), do: :circle
+  end
+end

--- a/test/support/entity_interface/rectangle.ex
+++ b/test/support/entity_interface/rectangle.ex
@@ -4,8 +4,4 @@ defmodule Example.EntityInterface.Rectangle do
         }
 
   defstruct id: ""
-
-  defimpl Absinthe.Federation.Schema.EntityUnion.Resolver do
-    def resolve_type(_, _), do: :rectangle
-  end
 end

--- a/test/support/entity_interface/rectangle.ex
+++ b/test/support/entity_interface/rectangle.ex
@@ -1,0 +1,11 @@
+defmodule Example.EntityInterface.Rectangle do
+  @type t :: %__MODULE__{
+          id: String.t()
+        }
+
+  defstruct id: ""
+
+  defimpl Absinthe.Federation.Schema.EntityUnion.Resolver do
+    def resolve_type(_, _), do: :rectangle
+  end
+end


### PR DESCRIPTION
Apollo Federation v2.3 introduced new @interfaceObject directive that allows users to extend entity functionality through inheritance. This allows entities to be interfaces (with some contraints). This PR addresses two issues:

1. Although an interface can be an entity with an `@key` directive, it should not be include in the `_Entity` union in the SDL.
1. While the type could be resolved, none of the fields could be realized. This meant that queries against an entity interface yielded null values. Invoking `resolve_type` for the interface type should result in materialized fields for correctly configured interfaces.

Thank you!