### PR TITLE
Add support for newer subgraph specification directives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,11 +139,11 @@ jobs:
         working-directory: ./federation_compatibility
 
       - name: Test subgraph compatibility
-        uses: apollographql/federation-subgraph-compatibility@v1
+        uses: apollographql/federation-subgraph-compatibility@v2
         with:
           compose: "federation_compatibility_docker_compose.yml"
           schema: "federation_compatibility/schema.graphql"
           token: ${{ steps.actionsecrets.outputs.github_token }}
           port: 4001
-          failOnWarning: true
+          failOnWarning: false
           failOnRequired: true

--- a/README.md
+++ b/README.md
@@ -318,16 +318,13 @@ defmodule Example.Schema do
 
 + extend schema do
 +   directive :link,
-+     url: "https://specs.apollo.dev/federation/v2.9",
++     url: "https://specs.apollo.dev/federation/v2.7",
 +     import: [
         "@authenticated",
-        "@context",
-        "@cost",
         "@extends",
         "@external",
         "@inaccessible",
         "@key",
-        "@listSize",
         "@override",
         "@policy",
         "@provides",

--- a/README.md
+++ b/README.md
@@ -318,19 +318,25 @@ defmodule Example.Schema do
 
 + extend schema do
 +   directive :link,
-+     url: "https://specs.apollo.dev/federation/v2.3",
++     url: "https://specs.apollo.dev/federation/v2.9",
 +     import: [
-+       "@key",
-+       "@shareable",
-+       "@provides",
-+       "@requires",
-+       "@external",
-+       "@tag",
-+       "@extends",
-+       "@override",
-+       "@inaccessible",
-+       "@composeDirective",
-+       "@interfaceObject"
+        "@authenticated",
+        "@context",
+        "@cost",
+        "@extends",
+        "@external",
+        "@inaccessible",
+        "@key",
+        "@listSize",
+        "@override",
+        "@policy",
+        "@provides",
+        "@requires",
+        "@requiresScopes",
+        "@shareable",
+        "@tag",
+        "@composeDirective",
+        "@interfaceObject"
 +     ]
 + end
 

--- a/federation_compatibility/lib/products_web/schema.ex
+++ b/federation_compatibility/lib/products_web/schema.ex
@@ -40,16 +40,13 @@ defmodule ProductsWeb.Schema do
     directive :link, url: "https://divvypay.com/test/v2.4", import: ["@custom"]
 
     directive :link,
-      url: "https://specs.apollo.dev/federation/v2.9",
+      url: "https://specs.apollo.dev/federation/v2.7",
       import: [
         "@authenticated",
-        "@context",
-        "@cost",
         "@extends",
         "@external",
         "@inaccessible",
         "@key",
-        "@listSize",
         "@override",
         "@policy",
         "@provides",

--- a/federation_compatibility/lib/products_web/schema.ex
+++ b/federation_compatibility/lib/products_web/schema.ex
@@ -40,15 +40,21 @@ defmodule ProductsWeb.Schema do
     directive :link, url: "https://divvypay.com/test/v2.4", import: ["@custom"]
 
     directive :link,
-      url: "https://specs.apollo.dev/federation/v2.3",
+      url: "https://specs.apollo.dev/federation/v2.9",
       import: [
+        "@authenticated",
+        "@context",
+        "@cost",
         "@extends",
         "@external",
         "@inaccessible",
         "@key",
+        "@listSize",
         "@override",
+        "@policy",
         "@provides",
         "@requires",
+        "@requiresScopes",
         "@shareable",
         "@tag",
         "@composeDirective",

--- a/lib/absinthe/federation/notation.ex
+++ b/lib/absinthe/federation/notation.ex
@@ -242,37 +242,9 @@ defmodule Absinthe.Federation.Notation do
         name: String @override(from: "SubgraphA")
       }
   """
-  defmacro override_from(subgraph) when is_binary(subgraph) do
+  defmacro override_from(subgraph) do
     quote do
       meta :override_from, unquote(subgraph)
-    end
-  end
-
-  @doc """
-  The progressive `@override` feature enables the gradual, progressive deployment of a subgraph with an @override field.
-
-  ## Example
-
-      object :user do
-        key_fields("id")
-        field :id, non_null(:id)
-
-        field :name, :string do
-          progressive_override(from: "SubgraphA", label: "percent(20)")
-        end
-      end
-
-
-  ## SDL Output
-
-      type User @key(fields: "id") {
-        id: ID!
-        name: String @override(from: "SubgraphA", label: "percent(20)")
-      }
-  """
-  defmacro progressive_override(args) when is_list(args) do
-    quote do
-      meta :progressive_override, unquote(args)
     end
   end
 
@@ -452,13 +424,13 @@ defmodule Absinthe.Federation.Notation do
 
   ## SDL Output
 
-    type User {
-      id: ID!
-      username: String
-      email: String
-      profileImage: String
-      credit_card: String @policy(policies: [["read_credit_card"]])
-    }
+      type User {
+        id: ID!
+        username: String
+        email: String
+        profileImage: String
+        credit_card: String @policy(policies: [["read_credit_card"]])
+      }
   """
   defmacro policy(policies) when is_list(policies) do
     quote do
@@ -471,29 +443,29 @@ defmodule Absinthe.Federation.Notation do
 
   ## Example
 
-     object :post do
-       field :text, :string
-     end
-
-     object :user do
-      field :posts, non_null(list_of(:post)) do
-        list_size(
-          assumed_size: 10, 
-          slicing_arguments: ["first", "last"],
-          sized_fields: ["postCount"],
-          required_one_slicing_argument: false
-        )
-        arg :first, :integer
-        arg :last, :integer
+      object :post do
+        field :text, :string
       end
-    end
+
+      object :user do
+       field :posts, non_null(list_of(:post)) do
+         list_size(
+           assumed_size: 10, 
+           slicing_arguments: ["first", "last"],
+           sized_fields: ["postCount"],
+           required_one_slicing_argument: false
+         )
+         arg :first, :integer
+         arg :last, :integer
+       end
+      end
 
 
   ## SDL Output
 
-    type User {
-      posts(first: Int, last: Int): [Post]! @listSize(assumedSize: 10, slicingArguments: ["first", "last"], sizedFields: ["postCount"], requiredOneSlicingArgument: false)
-    }
+      type User {
+        posts(first: Int, last: Int): [Post]! @listSize(assumedSize: 10, slicingArguments: ["first", "last"], sizedFields: ["postCount"], requiredOneSlicingArgument: false)
+      }
   """
   defmacro list_size(opts) when is_list(opts) do
     quote do

--- a/lib/absinthe/federation/schema/phase/add_federated_directives.ex
+++ b/lib/absinthe/federation/schema/phase/add_federated_directives.ex
@@ -35,6 +35,12 @@ defmodule Absinthe.Federation.Schema.Phase.AddFederatedDirectives do
     |> maybe_add_inaccessible_directive(meta)
     |> maybe_add_interface_object_directive(meta)
     |> maybe_add_tag_directive(meta)
+    |> maybe_add_requiresScopes_directive(meta)
+    |> maybe_add_policy_directive(meta)
+    |> maybe_add_authenticated_directive(meta)
+    |> maybe_add_context_directive(meta)
+    |> maybe_add_list_size_directive(meta)
+    |> maybe_add_cost_directive(meta)
   end
 
   @spec maybe_add_key_directive(term(), map()) :: term()
@@ -84,6 +90,54 @@ defmodule Absinthe.Federation.Schema.Phase.AddFederatedDirectives do
 
   defp maybe_add_extends_directive(node, _meta), do: node
 
+  defp maybe_add_requiresScopes_directive(node, %{requires_scopes: scopes, absinthe_adapter: adapter}) do
+    directive = Directive.build("requires_scopes", adapter, scopes: scopes)
+
+    add_directive(node, directive)
+  end
+
+  defp maybe_add_requiresScopes_directive(node, _meta), do: node
+
+  defp maybe_add_authenticated_directive(node, %{authenticated: true, absinthe_adapter: adapter}) do
+    directive = Directive.build("authenticated", adapter)
+
+    add_directive(node, directive)
+  end
+
+  defp maybe_add_authenticated_directive(node, _meta), do: node
+
+  defp maybe_add_policy_directive(node, %{policies: policies, absinthe_adapter: adapter}) do
+    directive = Directive.build("policy", adapter, policies: policies)
+
+    add_directive(node, directive)
+  end
+
+  defp maybe_add_policy_directive(node, _meta), do: node
+
+  defp maybe_add_context_directive(node, %{context: name, absinthe_adapter: adapter}) do
+    directive = Directive.build("context", adapter, name: name)
+
+    add_directive(node, directive)
+  end
+
+  defp maybe_add_context_directive(node, _meta), do: node
+
+  defp maybe_add_list_size_directive(node, %{list_size: args, absinthe_adapter: adapter}) do
+    directive = Directive.build("list_size", adapter, args)
+
+    add_directive(node, directive)
+  end
+
+  defp maybe_add_list_size_directive(node, _meta), do: node
+
+  defp maybe_add_cost_directive(node, %{cost: weight, absinthe_adapter: adapter}) do
+    directive = Directive.build("cost", adapter, weight: weight)
+
+    add_directive(node, directive)
+  end
+
+  defp maybe_add_cost_directive(node, _meta), do: node
+
   defp maybe_add_shareable_directive(node, %{shareable: true, absinthe_adapter: adapter}) do
     directive = Directive.build("shareable", adapter)
 
@@ -94,6 +148,12 @@ defmodule Absinthe.Federation.Schema.Phase.AddFederatedDirectives do
 
   defp maybe_add_override_directive(node, %{override_from: subgraph, absinthe_adapter: adapter}) do
     directive = Directive.build("override", adapter, from: subgraph)
+
+    add_directive(node, directive)
+  end
+
+  defp maybe_add_override_directive(node, %{progressive_override: args, absinthe_adapter: adapter}) do
+    directive = Directive.build("override", adapter, args)
 
     add_directive(node, directive)
   end

--- a/lib/absinthe/federation/schema/phase/add_federated_directives.ex
+++ b/lib/absinthe/federation/schema/phase/add_federated_directives.ex
@@ -35,7 +35,7 @@ defmodule Absinthe.Federation.Schema.Phase.AddFederatedDirectives do
     |> maybe_add_inaccessible_directive(meta)
     |> maybe_add_interface_object_directive(meta)
     |> maybe_add_tag_directive(meta)
-    |> maybe_add_requiresScopes_directive(meta)
+    |> maybe_add_requires_scopes_directive(meta)
     |> maybe_add_policy_directive(meta)
     |> maybe_add_authenticated_directive(meta)
     |> maybe_add_context_directive(meta)
@@ -90,13 +90,13 @@ defmodule Absinthe.Federation.Schema.Phase.AddFederatedDirectives do
 
   defp maybe_add_extends_directive(node, _meta), do: node
 
-  defp maybe_add_requiresScopes_directive(node, %{requires_scopes: scopes, absinthe_adapter: adapter}) do
+  defp maybe_add_requires_scopes_directive(node, %{requires_scopes: scopes, absinthe_adapter: adapter}) do
     directive = Directive.build("requires_scopes", adapter, scopes: scopes)
 
     add_directive(node, directive)
   end
 
-  defp maybe_add_requiresScopes_directive(node, _meta), do: node
+  defp maybe_add_requires_scopes_directive(node, _meta), do: node
 
   defp maybe_add_authenticated_directive(node, %{authenticated: true, absinthe_adapter: adapter}) do
     directive = Directive.build("authenticated", adapter)
@@ -146,13 +146,13 @@ defmodule Absinthe.Federation.Schema.Phase.AddFederatedDirectives do
 
   defp maybe_add_shareable_directive(node, _meta), do: node
 
-  defp maybe_add_override_directive(node, %{override_from: subgraph, absinthe_adapter: adapter}) do
+  defp maybe_add_override_directive(node, %{override_from: subgraph, absinthe_adapter: adapter}) when is_binary(subgraph) do
     directive = Directive.build("override", adapter, from: subgraph)
 
     add_directive(node, directive)
   end
 
-  defp maybe_add_override_directive(node, %{progressive_override: args, absinthe_adapter: adapter}) do
+  defp maybe_add_override_directive(node, %{override_from: args, absinthe_adapter: adapter}) when is_list(args) do
     directive = Directive.build("override", adapter, args)
 
     add_directive(node, directive)

--- a/lib/absinthe/federation/schema/phase/add_federated_directives.ex
+++ b/lib/absinthe/federation/schema/phase/add_federated_directives.ex
@@ -146,13 +146,7 @@ defmodule Absinthe.Federation.Schema.Phase.AddFederatedDirectives do
 
   defp maybe_add_shareable_directive(node, _meta), do: node
 
-  defp maybe_add_override_directive(node, %{override_from: subgraph, absinthe_adapter: adapter}) when is_binary(subgraph) do
-    directive = Directive.build("override", adapter, from: subgraph)
-
-    add_directive(node, directive)
-  end
-
-  defp maybe_add_override_directive(node, %{override_from: args, absinthe_adapter: adapter}) when is_list(args) do
+  defp maybe_add_override_directive(node, %{override_from: args, absinthe_adapter: adapter}) do
     directive = Directive.build("override", adapter, args)
 
     add_directive(node, directive)

--- a/lib/absinthe/federation/schema/prototype/federated_directives.ex
+++ b/lib/absinthe/federation/schema/prototype/federated_directives.ex
@@ -24,6 +24,16 @@ defmodule Absinthe.Federation.Schema.Prototype.FederatedDirectives do
         parse &{:ok, &1}
       end
 
+      scalar :federation_scope, name: "federation__Scope" do
+        serialize & &1
+        parse &{:ok, &1}
+      end
+
+      scalar :federation_policy, name: "federation__Policy" do
+        serialize & &1
+        parse &{:ok, &1}
+      end
+
       @desc """
       The `@key` directive is used to indicate a combination of fields that can be used
       to uniquely identify and fetch an object or interface.
@@ -79,6 +89,83 @@ defmodule Absinthe.Federation.Schema.Prototype.FederatedDirectives do
       end
 
       @desc """
+      The @requiresScopes directive marks fields and types as restricted based on required scopes.
+      The directive includes a scopes argument with an array of the required scopes to declare which scopes are required.
+      """
+      directive :requires_scopes do
+        arg :scopes, non_null(list_of(non_null(list_of(non_null(:federation_scope)))))
+
+        on [:field_definition, :object, :interface, :scalar, :enum]
+      end
+
+      @desc """
+      The @authenticated directive marks specific fields and types as requiring authentication.
+      It works by checking for the apollo::authentication::jwt_claims key in a request's context,
+      that is added either by the JWT authentication plugin, when the request contains a valid JWT,
+      or by an authentication coprocessor. If the key exists, it means the request is authenticated,
+      and the router executes the query in its entirety. If the request is unauthenticated, the router
+      removes @authenticated fields before planning the query and only executes the parts of the query
+      that don't require authentication.
+      """
+      directive :authenticated do
+        arg :scopes, non_null(list_of(non_null(list_of(non_null(:federation_scope)))))
+
+        on [:field_definition, :object, :interface, :scalar, :enum]
+      end
+
+      @desc """
+      The @policy directive marks fields and types as restricted based on authorization policies evaluated in a [Rhai script](https://www.apollographql.com/docs/graphos/routing/customization/rhai/) or
+      [coprocessor](https://www.apollographql.com/docs/router/customizations/coprocessor). This enables custom authorization validation beyond authentication and scopes. It is useful when we need more complex policy evaluation
+      than verifying the presence of a claim value in a list (example: checking specific values in headers).
+      """
+      directive :policy do
+        arg :policies, non_null(list_of(non_null(list_of(non_null(:federation_policy)))))
+
+        on [:field_definition, :object, :interface, :scalar, :enum]
+      end
+
+      @desc """
+      The @context directive defines a named context from which a field of the annotated type can be passed to a receiver of the context.
+      The receiver must be a field annotated with the @fromContext directive.  
+      """
+      directive :context do
+        arg :name, non_null(:string)
+
+        on [:object, :interface, :union]
+      end
+
+      @desc """
+      The @listSize directive is used to customize the cost calculation of the demand control feature of GraphOS Router.
+
+      In the static analysis phase, the cost calculator does not know how many entities will be returned by each list field in a given query.
+      By providing an estimated list size for a field with @listSize, the cost calculator can produce a more accurate estimate of the cost during static analysis.  
+      """
+      directive :list_size do
+        arg :assumed_size, :integer
+        arg :slicing_arguments, list_of(non_null(:string))
+        arg :sized_fields, list_of(non_null(:string))
+        arg :required_one_slicing_argument, :boolean, default_value: true
+
+        on [:field_definition]
+      end
+
+      @desc """
+      The @cost directive defines a custom weight for a schema location. For GraphOS Router, it customizes the operation cost calculation of the demand control feature.
+
+      If @cost is not specified for a field, a default value is used:
+
+        - Scalars and enums have default cost of 0
+        - Composite input and output types have default cost of 1
+
+      Regardless of whether @cost is specified on a field, the field cost for that field also accounts for its arguments and selections.  
+      """
+      directive :cost do
+        arg :weight, non_null(:integer)
+
+        on [:argument_definition, :enum, :field_definition, :input_field_definition, :object, :scalar]
+      end
+
+      @desc """
       The `@shareable` directive is used to indicate that a field can be resolved by multiple subgraphs.
       Any subgraph that includes a shareable field can potentially resolve a query for that field.
       To successfully compose, a field must have the same shareability mode (either shareable or non-shareable)
@@ -92,9 +179,16 @@ defmodule Absinthe.Federation.Schema.Prototype.FederatedDirectives do
       The `@override` directive is used to indicate that the current subgraph is
       taking responsibility for resolving the marked field away from
       the subgraph specified in the from argument.
+
+      The progressive @override feature enables the gradual, progressive deployment of a subgraph with an @override field.
+      As a subgraph developer, you can customize the percentage of traffic that the overriding and overridden subgraphs each resolve for a field.
+
+      see [Apollo Federation docs](https://www.apollographql.com/docs/graphos/schema-design/federated-schemas/reference/directives#progressive-override)
+      for details.
       """
       directive :override do
         arg :from, non_null(:string)
+        arg :label, :string
 
         on [:field_definition]
       end

--- a/test/absinthe/federation/notation_test.exs
+++ b/test/absinthe/federation/notation_test.exs
@@ -410,7 +410,7 @@ defmodule Absinthe.Federation.NotationTest do
         field :id, non_null(:id)
 
         field :amount, :integer do
-          progressive_override(from: "Payments", label: "percent(100)")
+          override_from(from: "Payments", label: "percent(100)")
         end
       end
     end

--- a/test/absinthe/federation/notation_test.exs
+++ b/test/absinthe/federation/notation_test.exs
@@ -410,14 +410,14 @@ defmodule Absinthe.Federation.NotationTest do
         field :id, non_null(:id)
 
         field :amount, :integer do
-          override_from(from: "Payments", label: "percent(100)")
+          override_from("Payments", label: "percent(10)")
         end
       end
     end
 
     sdl = Absinthe.Schema.to_sdl(ProgressiveOverrideSchema)
 
-    assert sdl =~ ~s{amount: Int @override(from: "Payments", label: "percent(100)")}
+    assert sdl =~ ~s{amount: Int @override(from: "Payments", label: "percent(10)")}
   end
 
   test "schema with override directive is valid" do


### PR DESCRIPTION
This PR adds support for newer Apollo Federation directives introduced in versions 2.4 through 2.9 of the Federation specification. This addresses feature request #108 for better compatibility with recent Federation versions.

### Added the following new directives:

- `@authenticated`
- `@requiresScopes`
- `@policy`
- `@cost`
- `@listSize`
- `@override (expanded functionality to incorporate the progressive override feature)`
- `@context` 

### Notes
The `@fromContext` directive has not been implemented in this PR since it would require modifying how directives can be applied to field arguments, which would be a more significant change. With that, I think that should be addressed in a separate PR.

Fixes #108