### PR TITLE
fix: adjust absinthe version dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -62,7 +62,7 @@ defmodule Absinthe.Federation.MixProject do
 
   defp deps do
     [
-      {:absinthe, ">= 1.7.6 and <= 1.9.0"},
+      {:absinthe, ">= 1.7.6"},
       {:dataloader, "~> 1.0.9 or ~> 1.0.10 or ~> 2.0"},
       # Dev
       {:dialyxir, ">= 1.0.0", only: [:dev, :test], runtime: false},


### PR DESCRIPTION
Hey team!

While updating to the latest version of `absinthe_federation`, I got an error due to the `absinthe` version dependency:

```shell
❯ mix deps.update absinthe_federation
Resolving Hex dependencies...
Resolution completed in 0.029s
Because "the lock" specifies absinthe 1.9.1 and absinthe_federation >= 0.9.0 depends on absinthe >= 1.7.6 and <= 1.9.0, the lock is incompatible with absinthe_federation >= 0.9.0.
And because your app depends on the lock, absinthe_federation >= 0.9.0 is forbidden.
So, because your app depends on absinthe_federation ~> 0.9, version solving failed.
** (Mix) Hex dependency resolution failed
```

I'm not sure if this was intentional or not, but looking at the [Absinthe 1.9.0..1.9.1 changes](https://diff.hex.pm/diff/absinthe/1.9.0..1.9.1), it doesn't look like that would break anything (and I didn't find any reasoning in the commits/code for this hard stop at 1.9.1).