### PR TITLE
Release v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.1
+
+- Bug Fix: [Fix absinthe dependency version for > v1.9.0](https://github.com/DivvyPayHQ/absinthe_federation/pull/122)
+
 ## 0.9.0
 
 - Bug Fix: [Allow `@tag` directive to be repeatable](https://github.com/DivvyPayHQ/absinthe_federation/pull/120)

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Absinthe.Federation.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/DivvyPayHQ/absinthe_federation"
-  @version "0.9.0"
+  @version "0.9.1"
 
   def project do
     [


### PR DESCRIPTION
- Bug Fix: [Fix absinthe dependency version for > v1.9.0](https://github.com/DivvyPayHQ/absinthe_federation/pull/122)