### PR TITLE
@cacheTag directive and Federation Support through 2.14

### DIFF
--- a/federation_compatibility/lib/products_web/schema.ex
+++ b/federation_compatibility/lib/products_web/schema.ex
@@ -40,7 +40,7 @@ defmodule ProductsWeb.Schema do
     directive :link, url: "https://divvypay.com/test/v2.4", import: ["@custom"]
 
     directive :link,
-      url: "https://specs.apollo.dev/federation/v2.12",
+      url: "https://specs.apollo.dev/federation/v2.13",
       import: [
         "@authenticated",
         "@cacheTag",

--- a/federation_compatibility/lib/products_web/schema.ex
+++ b/federation_compatibility/lib/products_web/schema.ex
@@ -40,9 +40,10 @@ defmodule ProductsWeb.Schema do
     directive :link, url: "https://divvypay.com/test/v2.4", import: ["@custom"]
 
     directive :link,
-      url: "https://specs.apollo.dev/federation/v2.7",
+      url: "https://specs.apollo.dev/federation/v2.12",
       import: [
         "@authenticated",
+        "@cacheTag",
         "@extends",
         "@external",
         "@inaccessible",

--- a/federation_compatibility/lib/products_web/schema.ex
+++ b/federation_compatibility/lib/products_web/schema.ex
@@ -40,7 +40,7 @@ defmodule ProductsWeb.Schema do
     directive :link, url: "https://divvypay.com/test/v2.4", import: ["@custom"]
 
     directive :link,
-      url: "https://specs.apollo.dev/federation/v2.13",
+      url: "https://specs.apollo.dev/federation/v2.14",
       import: [
         "@authenticated",
         "@cacheTag",

--- a/federation_compatibility/lib/products_web/schema.ex
+++ b/federation_compatibility/lib/products_web/schema.ex
@@ -40,10 +40,9 @@ defmodule ProductsWeb.Schema do
     directive :link, url: "https://divvypay.com/test/v2.4", import: ["@custom"]
 
     directive :link,
-      url: "https://specs.apollo.dev/federation/v2.14",
+      url: "https://specs.apollo.dev/federation/v2.7",
       import: [
         "@authenticated",
-        "@cacheTag",
         "@extends",
         "@external",
         "@inaccessible",

--- a/lib/absinthe/federation/notation.ex
+++ b/lib/absinthe/federation/notation.ex
@@ -555,7 +555,7 @@ defmodule Absinthe.Federation.Notation do
 
   @doc """
   The `@cacheTag` directive assigns cache tags to a field or type for use
-  with GraphOS Router's active cache invalidation feature (preview, Federation v2.12+).
+  with GraphOS Router's active cache invalidation feature (Federation v2.12+).
   The directive is repeatable — pass a list to apply multiple tags.
 
   ## Example

--- a/lib/absinthe/federation/notation.ex
+++ b/lib/absinthe/federation/notation.ex
@@ -554,6 +554,42 @@ defmodule Absinthe.Federation.Notation do
   end
 
   @doc """
+  The `@cacheTag` directive assigns cache tags to a field or type for use
+  with GraphOS Router's active cache invalidation feature (preview, Federation v2.12+).
+  The directive is repeatable — pass a list to apply multiple tags.
+
+  ## Example
+
+      object :product do
+        key_fields("id")
+        cache_tag("product-id")
+        field :id, non_null(:id)
+
+        field :price, :integer do
+          cache_tag(["price", "product-prices"])
+        end
+      end
+
+  ## SDL Output
+
+      type Product @cacheTag(format: "product-id") @key(fields: "id") {
+        id: ID!
+        price: Int @cacheTag(format: "price") @cacheTag(format: "product-prices")
+      }
+  """
+  defmacro cache_tag(format) when is_binary(format) do
+    quote do
+      meta :cache_tag, [unquote(format)]
+    end
+  end
+
+  defmacro cache_tag(formats) when is_list(formats) do
+    quote do
+      meta :cache_tag, unquote(formats)
+    end
+  end
+
+  @doc """
   The `@link` directive links definitions from an external specification to this schema.
   Every Federation 2 subgraph uses the `@link` directive to import the other federation-specific directives.
 

--- a/lib/absinthe/federation/schema/phase/add_federated_directives.ex
+++ b/lib/absinthe/federation/schema/phase/add_federated_directives.ex
@@ -40,6 +40,7 @@ defmodule Absinthe.Federation.Schema.Phase.AddFederatedDirectives do
     |> maybe_add_context_directive(meta)
     |> maybe_add_list_size_directive(meta)
     |> maybe_add_cost_directive(meta)
+    |> maybe_add_cache_tag_directive(meta)
   end
 
   @spec maybe_add_key_directive(term(), map()) :: term()
@@ -168,6 +169,14 @@ defmodule Absinthe.Federation.Schema.Phase.AddFederatedDirectives do
   end
 
   defp maybe_add_interface_object_directive(node, _meta), do: node
+
+  defp maybe_add_cache_tag_directive(node, %{cache_tag: formats, absinthe_adapter: adapter}) when is_list(formats) do
+    formats
+    |> Enum.map(&Directive.build("cache_tag", adapter, format: &1))
+    |> Enum.reduce(node, &add_directive(&2, &1))
+  end
+
+  defp maybe_add_cache_tag_directive(node, _meta), do: node
 
   defp add_directive(%{directives: directives} = node, directive) do
     %{node | directives: [directive | directives]}

--- a/lib/absinthe/federation/schema/prototype/federated_directives.ex
+++ b/lib/absinthe/federation/schema/prototype/federated_directives.ex
@@ -255,6 +255,17 @@ defmodule Absinthe.Federation.Schema.Prototype.FederatedDirectives do
         repeatable true
         on [:schema]
       end
+
+      @desc """
+      The @cacheTag directive assigns cache tags to fields or types to enable
+      fine-grained cache invalidation via the GraphOS Router cache.
+      This is a preview feature available in Federation v2.12+.
+      """
+      directive :cache_tag do
+        arg :format, non_null(:string)
+        repeatable true
+        on [:field_definition, :object]
+      end
     end
   end
 end

--- a/lib/absinthe/federation/schema/prototype/federated_directives.ex
+++ b/lib/absinthe/federation/schema/prototype/federated_directives.ex
@@ -259,7 +259,7 @@ defmodule Absinthe.Federation.Schema.Prototype.FederatedDirectives do
       @desc """
       The @cacheTag directive assigns cache tags to fields or types to enable
       fine-grained cache invalidation via the GraphOS Router cache.
-      This is a preview feature available in Federation v2.12+.
+      Available in Federation v2.12+.
       """
       directive :cache_tag do
         arg :format, non_null(:string)

--- a/test/absinthe/federation/notation_test.exs
+++ b/test/absinthe/federation/notation_test.exs
@@ -455,4 +455,36 @@ defmodule Absinthe.Federation.NotationTest do
 
     assert sdl =~ ~s{amount: Int @override(from: "Payments")}
   end
+
+  test "schema with cacheTag directive is valid" do
+    defmodule CacheTagSchema do
+      use Absinthe.Schema
+      use Absinthe.Federation.Schema
+
+      extend schema do
+        directive :link,
+          url: "https://specs.apollo.dev/federation/v2.12",
+          import: ["@cacheTag"]
+      end
+
+      query do
+        field :products, list_of(:product)
+      end
+
+      object :product do
+        key_fields("id")
+        cache_tag("product-id")
+        field :id, non_null(:id)
+
+        field :price, :integer do
+          cache_tag(["price", "product-prices"])
+        end
+      end
+    end
+
+    sdl = Absinthe.Schema.to_sdl(CacheTagSchema)
+
+    assert sdl =~ ~s{type Product @cacheTag(format: "product-id") @key(fields: "id")}
+    assert sdl =~ ~s{price: Int @cacheTag(format: "product-prices") @cacheTag(format: "price")}
+  end
 end


### PR DESCRIPTION
### Summary
Add support for the @cacheTag directive introduced as a preview feature in Federation v2.12, and advance the compatibility schema through v2.13 and v2.14.

Closes #125 

### Motivation
@cacheTag enables fine-grained cache invalidation via GraphOS Router's cache invalidation API. Without support in absinthe_federation, Elixir subgraphs cannot annotate fields or types with cache tags and must manage cache invalidation entirely outside the schema.

### Changes

### New directive: @cacheTag (Federation v2.12)

Spec definition:
```graphql
directive @cacheTag(format: String!) repeatable on FIELD_DEFINITION | OBJECT
```

Elixir API:
```elixir
object :product do
  key_fields("id")
  cache_tag("product")                                   # single tag

  field :id, non_null(:id)
  field :price, :integer do
    cache_tag(["price", "product-prices"])    # multiple tags (repeatable)
  end
end
```

SDL output:
```graphql
type Product @cacheTag(format: "product") @key(fields: "id") {
  id: ID!
  price: Int @cacheTag(format: "price") @cacheTag(format: "product-prices")
}
```

### Compatibility schema version bumps
v2.13: Connect v0.4 (Apollo Connectors) is a router/REST-mapping spec with no new subgraph directives.
v2.14: The @interfaceObject plus Fed1 coexistence relaxation and @link conflict validation are both composition-level only with no subgraph changes.

### Testing
All existing tests pass. New test added in notation_test.exs covering object-level and field-level @cacheTag usage including the repeatable/list form.