### PR TITLE
Fix atom exhaustion denial of service in `_entities`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.9.3
+
+- Security: [Fix atom exhaustion denial of service in `_entities`](https://github.com/DivvyPayHQ/absinthe_federation/pull/133)
+  > `_entities` representation keys were converted with `String.to_atom/1`.
+  > A client could send arbitrary unique keys and exhaust the BEAM atom table.
+  > Keys now resolve with `String.to_existing_atom/1` and keys that match no
+  > existing atom pass through as strings instead of being converted.
+  > Also fixes structs in representations being flattened into plain maps.
+
 ## 0.9.2
 
 - Feature: [Support `@cacheTag` directive](https://github.com/DivvyPayHQ/absinthe_federation/pull/126)

--- a/lib/absinthe/federation/schema/entities_field.ex
+++ b/lib/absinthe/federation/schema/entities_field.ex
@@ -233,26 +233,37 @@ defmodule Absinthe.Federation.Schema.EntitiesField do
     end
   end
 
-  defp convert_keys_to_atom(map, context) when is_map(map) do
+  # Representation keys come from the open-ended `_Any` scalar, i.e. arbitrary
+  # client-supplied strings that bypass schema coercion. We only use atoms that
+  # already exist since every field of every type in the schema is an atom at
+  # compile time, so legitimate keys always convert.
+  # Unknown keys stay strings instead of being dropped.
+  defp convert_keys_to_atom(map, context) when is_map(map) and not is_struct(map) do
     Map.new(map, fn {k, v} ->
-      k = convert_key(k, context)
-      v = convert_keys_to_atom(v, context)
-      {k, v}
+      {convert_key(k, context), convert_keys_to_atom(v, context)}
     end)
   end
 
   defp convert_keys_to_atom(v, _context), do: v
 
-  defp convert_key(k, context) do
-    adapter = Map.get(context, :adapter, LanguageConventions)
+  defp convert_key(k, context) when is_binary(k) do
+    adapter = Map.get(context, :adapter) || LanguageConventions
 
-    if adapter_has_to_internal_name_modifier?(adapter) do
-      adapter.to_internal_name(k, :field)
-    else
-      k
+    name =
+      if adapter_has_to_internal_name_modifier?(adapter) do
+        adapter.to_internal_name(k, :field)
+      else
+        k
+      end
+
+    try do
+      String.to_existing_atom(name)
+    rescue
+      ArgumentError -> k
     end
-    |> String.to_atom()
   end
+
+  defp convert_key(k, _context), do: k
 
   defp run_callbacks(plugins, callback, acc) do
     Enum.reduce(plugins, acc, &apply(&1, callback, [&2]))

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Absinthe.Federation.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/DivvyPayHQ/absinthe_federation"
-  @version "0.9.2"
+  @version "0.9.3"
 
   def project do
     [

--- a/test/absinthe/federation/schema/resolve_reference_test.exs
+++ b/test/absinthe/federation/schema/resolve_reference_test.exs
@@ -36,25 +36,25 @@ defmodule Absinthe.Federation.Schema.ResolveReferenceTest do
   end
 
   describe "_resolve_reference" do
-    test "resolves entity fields correctly" do
-      query = """
-        query GetHousePlantEntities($representations: [_Any!]!) {
-          _entities(representations: $representations) {
-            ... on HousePlant {
-              id
-              name
-              waterInterval
-              __typename
-            }
+    @query """
+      query GetHousePlantEntities($representations: [_Any!]!) {
+        _entities(representations: $representations) {
+          ... on HousePlant {
+            id
+            name
+            waterInterval
+            __typename
           }
         }
-      """
+      }
+    """
 
+    test "resolves entity fields correctly" do
       id = "8b89136b-85d7-4eb4-b8a3-608a7d078c5e"
 
       options = [variables: %{"representations" => [%{"id" => id, "__typename" => "HousePlant"}]}]
 
-      result = Absinthe.run(query, TestSchema, options)
+      result = Absinthe.run(@query, TestSchema, options)
 
       assert {:ok,
               %{
@@ -62,13 +62,64 @@ defmodule Absinthe.Federation.Schema.ResolveReferenceTest do
                   "_entities" => [
                     %{
                       "__typename" => "HousePlant",
-                      "id" => ^id,
+                      "id" => id,
                       "name" => "Snake Plant",
                       "waterInterval" => 14
                     }
                   ]
                 }
-              }} = result
+              }} == result
     end
+  end
+
+  test "does not create new atoms for unknown representation keys" do
+    id = "8b89136b-85d7-4eb4-b8a3-608a7d078c5e"
+
+    representations = fn n ->
+      for i <- 1..n do
+        %{"id" => id, "__typename" => "HousePlant", "attacker_key_#{i}" => "x"}
+      end
+    end
+
+    # Warm up: run once to trigger any one-time lazy module loading first
+    {:ok, _warmup} = Absinthe.run(@query, TestSchema, variables: %{"representations" => representations.(1)})
+
+    atom_count_before = :erlang.system_info(:atom_count)
+
+    {:ok, _result} = Absinthe.run(@query, TestSchema, variables: %{"representations" => representations.(2_000)})
+
+    atom_count_after = :erlang.system_info(:atom_count)
+
+    # Loose assertion due to possible lazy loading while running the full test suite
+    # If the code created non-existent atoms this would cause >= 2000 difference
+    assert atom_count_after - atom_count_before < 99
+  end
+
+  test "unknown representation keys do not prevent resolution" do
+    id = "8b89136b-85d7-4eb4-b8a3-608a7d078c5e"
+
+    options = [
+      variables: %{
+        "representations" => [
+          %{"id" => id, "__typename" => "HousePlant", "some_unknown_key_zzz" => "ignored"}
+        ]
+      }
+    ]
+
+    result = Absinthe.run(@query, TestSchema, options)
+
+    assert {:ok,
+            %{
+              data: %{
+                "_entities" => [
+                  %{
+                    "__typename" => "HousePlant",
+                    "id" => id,
+                    "name" => "Snake Plant",
+                    "waterInterval" => 14
+                  }
+                ]
+              }
+            }} == result
   end
 end


### PR DESCRIPTION
`_entities` representation keys were converted with `String.to_atom/1`.
A client could send arbitrary unique keys and exhaust the BEAM atom table.
Keys now resolve with `String.to_existing_atom/1` and keys that match no
existing atom pass through as strings instead of being converted.
Also fixes structs in representations being flattened into plain maps.