### PR TITLE
Atomize keys in entities field resolver with list-valued representations

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,6 +1,11 @@
 # Used by "mix format"
 [
-  inputs: ["{mix,.formatter}.exs", "{config,lib,test,federation_compatibility}/**/*.{ex,exs}"],
+  inputs: [
+    "{mix,.formatter}.exs",
+    "{config,lib,test}/**/*.{ex,exs}",
+    "federation_compatibility/{mix,.formatter}.exs",
+    "federation_compatibility/{config,lib,test}/**/*.{ex,exs}"
+  ],
   line_length: 120,
   import_deps: [:absinthe]
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## Unreleased
+
+- **BREAKING**: [Convert `_entities` representation keys nested in lists to atoms](https://github.com/DivvyPayHQ/absinthe_federation/pull/135)
+
+  > Previously, a map inside a list-typed representation field (e.g. a
+  > list-shaped `@key` field) kept string keys after conversion, while a map
+  > nested directly under another map already converted to atom keys. This
+  > was an inconsistency and now nested keys will also be converted as long as
+  > they are existing atoms.
+  > If your `_resolve_reference` resolver pattern-matches on string keys for a
+  > list-nested representation field, update it to match atom keys instead.
+  >
+  > Example before:
+  >
+  > ```elixir
+  > def resolver_function(_, args, _) do
+  >   tag_ids = Enum.map(args.tags, & Map.get(&1, "id"))
+  >   {:ok, %{id: args.id, tag_ids: tag_ids, __typename: "Widget"}}
+  > end
+  > ```
+  >
+  > After:
+  >
+  > ```elixir
+  > def resolver_function(_, args, _) do
+  >   tag_ids = Enum.map(args.tags, & &1.id)
+  >   {:ok, %{id: args.id, tag_ids: tag_ids, __typename: "Widget"}}
+  > end
+  > ```
+
 ## 0.9.3
 
 - Security: [Fix atom exhaustion denial of service in `_entities`](https://github.com/DivvyPayHQ/absinthe_federation/pull/133)

--- a/lib/absinthe/federation/schema/entities_field.ex
+++ b/lib/absinthe/federation/schema/entities_field.ex
@@ -244,6 +244,10 @@ defmodule Absinthe.Federation.Schema.EntitiesField do
     end)
   end
 
+  defp convert_keys_to_atom(list, context) when is_list(list) do
+    Enum.map(list, &convert_keys_to_atom(&1, context))
+  end
+
   defp convert_keys_to_atom(v, _context), do: v
 
   defp convert_key(k, context) when is_binary(k) do

--- a/test/absinthe/federation/schema/entities_field_test.exs
+++ b/test/absinthe/federation/schema/entities_field_test.exs
@@ -549,6 +549,58 @@ defmodule Absinthe.Federation.Schema.EntitiesFieldTest do
     end
   end
 
+  describe "resolver with list-valued fields" do
+    defmodule ListKeyResolverSchema do
+      use Absinthe.Schema
+      use Absinthe.Federation.Schema
+
+      query do
+        field :test, :string
+      end
+
+      object :widget do
+        key_fields("id")
+        field :id, non_null(:id)
+        field :tag_ids, list_of(:string)
+
+        field :_resolve_reference, :widget do
+          resolve(fn _, args, _ ->
+            # `tags` arrives as a list of maps; each map's keys must be atoms
+            # (e.g. :id) for this pattern match to succeed, same as a
+            # directly-nested map would be.
+            tag_ids = Enum.map(args.tags, & &1.id)
+            {:ok, %{id: args.id, tag_ids: tag_ids, __typename: "Widget"}}
+          end)
+        end
+      end
+    end
+
+    test "converts keys inside list values" do
+      query = """
+        query GetWidgets($representations: [_Any!]!) {
+          _entities(representations: $representations) {
+            ...on Widget {
+              id
+              tagIds
+            }
+          }
+        }
+      """
+
+      representations = [
+        %{
+          "__typename" => "Widget",
+          "id" => "1",
+          "tags" => [%{"id" => "a"}, %{"id" => "b"}]
+        }
+      ]
+
+      {:ok, resp} = Absinthe.run(query, ListKeyResolverSchema, variables: %{"representations" => representations})
+
+      assert %{data: %{"_entities" => [%{"id" => "1", "tagIds" => ["a", "b"]}]}} == resp
+    end
+  end
+
   describe "parent type with proper case" do
     defmodule SchemaWithLongKeyFieldName do
       use Absinthe.Schema

--- a/test/absinthe/federation/schema/resolve_reference_test.exs
+++ b/test/absinthe/federation/schema/resolve_reference_test.exs
@@ -72,27 +72,17 @@ defmodule Absinthe.Federation.Schema.ResolveReferenceTest do
     end
   end
 
-  test "does not create new atoms for unknown representation keys" do
+  test "does not create an atom for an unknown representation key" do
     id = "8b89136b-85d7-4eb4-b8a3-608a7d078c5e"
+    unknown_key = "arbitrary_key_#{System.unique_integer([:positive])}"
 
-    representations = fn n ->
-      for i <- 1..n do
-        %{"id" => id, "__typename" => "HousePlant", "attacker_key_#{i}" => "x"}
-      end
-    end
+    options = [
+      variables: %{"representations" => [%{"id" => id, "__typename" => "HousePlant", unknown_key => "x"}]}
+    ]
 
-    # Warm up: run once to trigger any one-time lazy module loading first
-    {:ok, _warmup} = Absinthe.run(@query, TestSchema, variables: %{"representations" => representations.(1)})
+    {:ok, _result} = Absinthe.run(@query, TestSchema, options)
 
-    atom_count_before = :erlang.system_info(:atom_count)
-
-    {:ok, _result} = Absinthe.run(@query, TestSchema, variables: %{"representations" => representations.(2_000)})
-
-    atom_count_after = :erlang.system_info(:atom_count)
-
-    # Loose assertion due to possible lazy loading while running the full test suite
-    # If the code created non-existent atoms this would cause >= 2000 difference
-    assert atom_count_after - atom_count_before < 99
+    assert_raise ArgumentError, ~r/not an already existing atom/, fn -> String.to_existing_atom(unknown_key) end
   end
 
   test "unknown representation keys do not prevent resolution" do


### PR DESCRIPTION
A map inside a list-typed representation field (e.g. a list-shaped `@key` field) kept string keys after conversion, while a map nested directly under another map already converted to atom keys. This was an inconsistency and now nested keys will also be converted as long as they are existing atoms.